### PR TITLE
Feat: OCR 결과 기반 자격증 매칭 기능 구현

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateMaster.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateMaster.java
@@ -1,0 +1,38 @@
+package com.nudgebank.bankbackend.certificate.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "certificate_master")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CertificateMaster {
+
+    @Id
+    @Column(name = "certificate_id")
+    private Long certificateId;
+
+    @Column(name = "certificate_name", length = 200)
+    private String certificateName;
+
+    @Column(name = "issuer_name", length = 200)
+    private String issuerName;
+
+    @Column(name = "rate_discount")
+    private BigDecimal rateDiscount;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
@@ -50,4 +50,9 @@ public class CertificateSubmission {
 
     @Column(name = "verified_at")
     private OffsetDateTime verifiedAt;
+
+    public void updateVerification(String verificationStatus, OffsetDateTime verifiedAt) {
+        this.verificationStatus = verificationStatus;
+        this.verifiedAt = verifiedAt;
+    }
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateVerificationStatus.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateVerificationStatus.java
@@ -1,0 +1,6 @@
+package com.nudgebank.bankbackend.certificate.domain;
+
+public enum CertificateVerificationStatus {
+    VERIFIED,
+    VERIFICATION_FAILED
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
@@ -1,0 +1,11 @@
+package com.nudgebank.bankbackend.certificate.dto;
+
+import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
+
+import java.time.OffsetDateTime;
+
+public record CertificateMatchResult(
+        CertificateVerificationStatus verificationStatus,
+        OffsetDateTime verifiedAt
+) {
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/exception/CertificateVerificationException.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/exception/CertificateVerificationException.java
@@ -1,0 +1,8 @@
+package com.nudgebank.bankbackend.certificate.exception;
+
+public class CertificateVerificationException extends RuntimeException {
+
+    public CertificateVerificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateMasterRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateMasterRepository.java
@@ -1,0 +1,10 @@
+package com.nudgebank.bankbackend.certificate.repository;
+
+import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CertificateMasterRepository extends JpaRepository<CertificateMaster, Long> {
+    Optional<CertificateMaster> findByCertificateIdAndIsActiveTrue(Long certificateId);
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
@@ -1,6 +1,7 @@
 package com.nudgebank.bankbackend.certificate.service;
 
 import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
+import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
 import com.nudgebank.bankbackend.certificate.repository.CertificateSubmissionRepository;
 import com.nudgebank.bankbackend.ocr.client.OcrClient;
@@ -15,17 +16,18 @@ import java.time.OffsetDateTime;
 @Service
 public class CertificateSubmissionService {
 
-    private static final String VERIFICATION_STATUS_COMPLETED = "OCR_COMPLETED";
-
     private final CertificateSubmissionRepository certificateSubmissionRepository;
     private final OcrClient ocrClient;
+    private final CertificateVerificationService certificateVerificationService;
 
     public CertificateSubmissionService(
             CertificateSubmissionRepository certificateSubmissionRepository,
-            OcrClient ocrClient
+            OcrClient ocrClient,
+            CertificateVerificationService certificateVerificationService
     ) {
         this.certificateSubmissionRepository = certificateSubmissionRepository;
         this.ocrClient = ocrClient;
+        this.certificateVerificationService = certificateVerificationService;
     }
 
     @Transactional
@@ -39,6 +41,7 @@ public class CertificateSubmissionService {
 
         OcrExtractResponse ocrResponse = ocrClient.extract(file);
         OffsetDateTime submittedAt = OffsetDateTime.now();
+        CertificateMatchResult matchResult = certificateVerificationService.verify(certificateId, ocrResponse.extractedText());
 
         CertificateSubmission submission = CertificateSubmission.builder()
                 .memberId(memberId)
@@ -46,9 +49,9 @@ public class CertificateSubmissionService {
                 .certificateId(certificateId)
                 .fileUrl(file.getOriginalFilename())
                 .ocrText(ocrResponse.extractedText())
-                .verificationStatus(VERIFICATION_STATUS_COMPLETED)
+                .verificationStatus(matchResult.verificationStatus().name())
                 .submittedAt(submittedAt)
-                .verifiedAt(submittedAt)
+                .verifiedAt(matchResult.verifiedAt())
                 .build();
 
         CertificateSubmission savedSubmission = certificateSubmissionRepository.save(submission);
@@ -60,7 +63,7 @@ public class CertificateSubmissionService {
                 ocrResponse.extractedText(),
                 ocrResponse.lines(),
                 ocrResponse.lineCount(),
-                savedSubmission.getVerificationStatus(),
+                matchResult.verificationStatus().name(),
                 savedSubmission.getSubmittedAt()
         );
     }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -42,7 +42,12 @@ public class CertificateVerificationService {
     }
 
     private boolean contains(String normalizedText, String expectedValue) {
-        return normalizedText.contains(normalize(expectedValue));
+        String normalizedExpectedValue = normalize(expectedValue);
+        if (normalizedExpectedValue.isBlank()) {
+            return false;
+        }
+
+        return normalizedText.contains(normalizedExpectedValue);
     }
 
     private String normalize(String value) {

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -1,0 +1,58 @@
+package com.nudgebank.bankbackend.certificate.service;
+
+import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
+import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
+import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
+import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
+import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
+import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
+import java.time.OffsetDateTime;
+import java.util.Locale;
+
+@Service
+public class CertificateVerificationService {
+
+    private final CertificateMasterRepository certificateMasterRepository;
+
+    public CertificateVerificationService(CertificateMasterRepository certificateMasterRepository) {
+        this.certificateMasterRepository = certificateMasterRepository;
+    }
+
+    public CertificateMatchResult verify(Long certificateId, String extractedText) {
+        CertificateMaster certificateMaster = certificateMasterRepository.findByCertificateIdAndIsActiveTrue(certificateId)
+                .orElseThrow(() -> new CertificateVerificationException("Active certificate master not found"));
+
+        String normalizedText = normalize(extractedText);
+        boolean certificateNameMatched = contains(normalizedText, certificateMaster.getCertificateName());
+        boolean issuerNameMatched = contains(normalizedText, certificateMaster.getIssuerName());
+
+        if (certificateNameMatched && issuerNameMatched) {
+            return new CertificateMatchResult(
+                    CertificateVerificationStatus.VERIFIED,
+                    OffsetDateTime.now()
+            );
+        }
+
+        return new CertificateMatchResult(
+                CertificateVerificationStatus.VERIFICATION_FAILED,
+                null
+        );
+    }
+
+    private boolean contains(String normalizedText, String expectedValue) {
+        return normalizedText.contains(normalize(expectedValue));
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+
+        String normalized = Normalizer.normalize(value, Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT);
+
+        return normalized.replaceAll("[^\\p{IsAlphabetic}\\p{IsDigit}]", "");
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nudgebank/bankbackend/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.nudgebank.bankbackend.common.exception;
 
+import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
 import com.nudgebank.bankbackend.ocr.exception.InvalidCertificateUploadException;
 import com.nudgebank.bankbackend.ocr.exception.OcrClientException;
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
                 .body(new ErrorResponse(
                         HttpStatus.BAD_GATEWAY.value(),
+                        exception.getMessage(),
+                        OffsetDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(CertificateVerificationException.class)
+    public ResponseEntity<ErrorResponse> handleCertificateVerificationException(CertificateVerificationException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        HttpStatus.BAD_REQUEST.value(),
                         exception.getMessage(),
                         OffsetDateTime.now()
                 ));


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #12 

---

### 📝 작업 내용
- OCR 서버에서 추출한 텍스트를 바탕으로 자격증명과 발급기관 매칭 로직을 추가했습니다.
- `certificate_master` 기준 자격증 정보를 조회하는 도메인 및 레포지토리를 추가했습니다.
- OCR 텍스트를 정규화한 뒤 자격증명 및 발급기관 포함 여부를 비교하도록 구현했습니다.
- 매칭 결과에 따라 `VERIFIED`, `VERIFICATION_FAILED` 상태값을 판별하도록 구현했습니다.
- 인증 결과가 `certificate_submission.verification_status`와 `verified_at`에 저장되도록 반영했습니다.
- 자격증 기준 정보가 없을 경우 예외 처리하도록 구현했습니다.

---

### 📷 스크린샷 (선택)
- <img width="503" height="156" alt="image" src="https://github.com/user-attachments/assets/19776db7-b33a-4134-946e-825b5c952e46" />
<img width="1121" height="108" alt="image" src="https://github.com/user-attachments/assets/014c0286-6bac-44c9-83eb-7a370422ac33" />


---

## ✅ 체크리스트
- [x] PR 제목 규칙을 지켰다
- [x] 추가/수정 사항을 설명했다
- [x] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증서 검증 기능 추가: 제출된 인증서의 추출 텍스트와 저장된 인증서 정보를 비교하여 검증합니다.
  * 검증 결과를 VERIFIED(승인) 또는 VERIFICATION_FAILED(검증 실패)로 반환하고, 검증 시각을 기록합니다.
  * 제출 응답에 검증 결과 및 타임스탬프를 반영합니다.
* **버그 수정 / 오류 처리**
  * 활성 인증서가 없을 경우 검증 요청에 대해 400 Bad Request 및 오류 메시지를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->