### PR TITLE
Fix: OCR 서버 호출 타임아웃 개선

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/ocr/client/OcrClient.java
+++ b/src/main/java/com/nudgebank/bankbackend/ocr/client/OcrClient.java
@@ -4,17 +4,21 @@ import com.nudgebank.bankbackend.ocr.dto.OcrExtractResponse;
 import com.nudgebank.bankbackend.ocr.exception.InvalidCertificateUploadException;
 import com.nudgebank.bankbackend.ocr.exception.OcrClientException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.MediaType;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
 
 @Component
 public class OcrClient {
@@ -23,9 +27,18 @@ public class OcrClient {
 
     private final RestClient restClient;
 
-    public OcrClient(@Value("${ocr.base-url:http://localhost:8000}") String ocrBaseUrl) {
+    public OcrClient(
+            @Value("${ocr.base-url:http://localhost:8000}") String ocrBaseUrl,
+            @Value("${ocr.connect-timeout-ms:5000}") int connectTimeoutMs,
+            @Value("${ocr.read-timeout-ms:120000}") int readTimeoutMs
+    ) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
+        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+
         this.restClient = RestClient.builder()
                 .baseUrl(ocrBaseUrl)
+                .requestFactory(requestFactory)
                 .build();
     }
 
@@ -46,6 +59,12 @@ public class OcrClient {
             }
 
             return response;
+        } catch (ResourceAccessException exception) {
+            if (hasTimeoutCause(exception)) {
+                throw new OcrClientException("OCR server response timed out", exception);
+            }
+
+            throw new OcrClientException("Failed to connect to OCR server", exception);
         } catch (RestClientResponseException exception) {
             throw new OcrClientException(
                     "OCR server request failed with status %s: %s".formatted(
@@ -59,6 +78,23 @@ public class OcrClient {
         } catch (IOException exception) {
             throw new InvalidCertificateUploadException("Failed to read upload file", exception);
         }
+    }
+
+    private boolean hasTimeoutCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SocketTimeoutException) {
+                return true;
+            }
+
+            if ("ReadTimeoutException".equals(current.getClass().getSimpleName())) {
+                return true;
+            }
+
+            current = current.getCause();
+        }
+
+        return false;
     }
 
     private static final class NamedByteArrayResource extends ByteArrayResource {

--- a/src/main/java/com/nudgebank/bankbackend/ocr/client/OcrClient.java
+++ b/src/main/java/com/nudgebank/bankbackend/ocr/client/OcrClient.java
@@ -28,9 +28,9 @@ public class OcrClient {
     private final RestClient restClient;
 
     public OcrClient(
-            @Value("${ocr.base-url:http://localhost:8000}") String ocrBaseUrl,
-            @Value("${ocr.connect-timeout-ms:5000}") int connectTimeoutMs,
-            @Value("${ocr.read-timeout-ms:120000}") int readTimeoutMs
+            @Value("${ocr.base-url}") String ocrBaseUrl,
+            @Value("${ocr.connect-timeout-ms}") int connectTimeoutMs,
+            @Value("${ocr.read-timeout-ms}") int readTimeoutMs
     ) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #25 

---

### 📝 작업 내용
- OCR 서버 호출 클라이언트에 connect timeout 및 read timeout 설정을 추가했습니다.
- 기본 timeout 값을 코드에 적용하고, 필요 시 로컬 설정 파일에서 override 가능하도록 구성했습니다.
- OCR 서버 응답 지연 시 timeout 예외를 구분해 `OCR server response timed out` 메시지로 처리하도록 수정했습니다.
- OCR 서버 연결 실패와 응답 지연을 구분해 예외 메시지를 개선했습니다.
- 일부 PDF 업로드 시 발생하던 `ReadTimeoutException` 상황을 고려해 배포 환경에서도 조정 가능한 형태로 정리했습니다.
---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * OCR 서버 통신 시 타임아웃 처리 개선으로 더 명확한 오류 메시지 제공
  * 연결 타임아웃과 읽기 타임아웃을 구분하여 사용자에게 정확한 오류 정보 전달

<!-- end of auto-generated comment: release notes by coderabbit.ai -->