### PR TITLE
Feat: OCR 자격증 매칭 정확도 개선

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateIssuerAlias.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateIssuerAlias.java
@@ -2,6 +2,8 @@ package com.nudgebank.bankbackend.certificate.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -11,26 +13,24 @@ import lombok.NoArgsConstructor;
 import java.time.OffsetDateTime;
 
 @Entity
-@Table(name = "certificate_master")
+@Table(name = "certificate_issuer_alias")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CertificateMaster {
+public class CertificateIssuerAlias {
 
     @Id
-    @Column(name = "certificate_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "alias_id")
+    private Long aliasId;
+
+    @Column(name = "certificate_id", nullable = false)
     private Long certificateId;
 
-    @Column(name = "certificate_name", length = 200)
-    private String certificateName;
+    @Column(name = "issuer_name", length = 200)
+    private String issuerName;
 
-    @Column(name = "certificate_code", length = 50)
-    private String certificateCode;
-
-    @Column(name = "certificate_name_en", length = 200)
-    private String certificateNameEn;
-
-    @Column(name = "certificate_category", length = 100)
-    private String certificateCategory;
+    @Column(name = "issuer_name_en", length = 200)
+    private String issuerNameEn;
 
     @Column(name = "is_active")
     private Boolean isActive;

--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
@@ -30,11 +30,14 @@ public class CertificateSubmission {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    @Column(name = "loan_id", nullable = false)
-    private Long loanId;
+    @Column(name = "loan_application_id", nullable = false)
+    private Long loanApplicationId;
 
     @Column(name = "certificate_id", nullable = false)
     private Long certificateId;
+
+    @Column(name = "matched_issuer_name", length = 200)
+    private String matchedIssuerName;
 
     @Column(name = "file_url", length = 500)
     private String fileUrl;
@@ -42,8 +45,20 @@ public class CertificateSubmission {
     @Column(name = "ocr_text", columnDefinition = "TEXT")
     private String ocrText;
 
+    @Column(name = "match_score", precision = 5, scale = 2)
+    private java.math.BigDecimal matchScore;
+
+    @Column(name = "detected_name", length = 100)
+    private String detectedName;
+
+    @Column(name = "name_match_yn")
+    private Boolean nameMatchYn;
+
     @Column(name = "verification_status", length = 30)
     private String verificationStatus;
+
+    @Column(name = "review_note", length = 500)
+    private String reviewNote;
 
     @Column(name = "submitted_at")
     private OffsetDateTime submittedAt;

--- a/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
@@ -2,10 +2,16 @@ package com.nudgebank.bankbackend.certificate.dto;
 
 import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 public record CertificateMatchResult(
         CertificateVerificationStatus verificationStatus,
-        OffsetDateTime verifiedAt
+        OffsetDateTime verifiedAt,
+        BigDecimal matchScore,
+        String matchedIssuerName,
+        String detectedName,
+        boolean nameMatched,
+        String reviewNote
 ) {
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateIssuerAliasRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateIssuerAliasRepository.java
@@ -1,0 +1,10 @@
+package com.nudgebank.bankbackend.certificate.repository;
+
+import com.nudgebank.bankbackend.certificate.domain.CertificateIssuerAlias;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CertificateIssuerAliasRepository extends JpaRepository<CertificateIssuerAlias, Long> {
+    List<CertificateIssuerAlias> findAllByCertificateIdAndIsActiveTrue(Long certificateId);
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateSubmissionRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateSubmissionRepository.java
@@ -4,4 +4,9 @@ import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CertificateSubmissionRepository extends JpaRepository<CertificateSubmission, Long> {
+    boolean existsByMemberIdAndCertificateIdAndVerificationStatus(
+            Long memberId,
+            Long certificateId,
+            String verificationStatus
+    );
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
@@ -1,5 +1,8 @@
 package com.nudgebank.bankbackend.certificate.service;
 
+import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.auth.repository.MemberRepository;
+import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
 import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
@@ -11,20 +14,24 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @Service
 public class CertificateSubmissionService {
 
+    private final MemberRepository memberRepository;
     private final CertificateSubmissionRepository certificateSubmissionRepository;
     private final OcrClient ocrClient;
     private final CertificateVerificationService certificateVerificationService;
 
     public CertificateSubmissionService(
+            MemberRepository memberRepository,
             CertificateSubmissionRepository certificateSubmissionRepository,
             OcrClient ocrClient,
             CertificateVerificationService certificateVerificationService
     ) {
+        this.memberRepository = memberRepository;
         this.certificateSubmissionRepository = certificateSubmissionRepository;
         this.ocrClient = ocrClient;
         this.certificateVerificationService = certificateVerificationService;
@@ -38,18 +45,32 @@ public class CertificateSubmissionService {
             MultipartFile file
     ) {
         validateRequest(memberId, loanId, certificateId, file);
+        validateDuplicateSubmission(memberId, certificateId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new InvalidCertificateUploadException("Member not found"));
 
         OcrExtractResponse ocrResponse = ocrClient.extract(file);
         OffsetDateTime submittedAt = OffsetDateTime.now();
-        CertificateMatchResult matchResult = certificateVerificationService.verify(certificateId, ocrResponse.extractedText());
+        CertificateMatchResult matchResult = certificateVerificationService.verify(
+                member,
+                certificateId,
+                ocrResponse.extractedText(),
+                ocrResponse.lines()
+        );
 
         CertificateSubmission submission = CertificateSubmission.builder()
                 .memberId(memberId)
-                .loanId(loanId)
+                .loanApplicationId(loanId)
                 .certificateId(certificateId)
+                .matchedIssuerName(matchResult.matchedIssuerName())
                 .fileUrl(file.getOriginalFilename())
                 .ocrText(ocrResponse.extractedText())
+                .matchScore(defaultScore(matchResult.matchScore()))
+                .detectedName(matchResult.detectedName())
+                .nameMatchYn(matchResult.nameMatched())
                 .verificationStatus(matchResult.verificationStatus().name())
+                .reviewNote(matchResult.reviewNote())
                 .submittedAt(submittedAt)
                 .verifiedAt(matchResult.verifiedAt())
                 .build();
@@ -66,6 +87,20 @@ public class CertificateSubmissionService {
                 matchResult.verificationStatus().name(),
                 savedSubmission.getSubmittedAt()
         );
+    }
+
+    private void validateDuplicateSubmission(Long memberId, Long certificateId) {
+        if (certificateSubmissionRepository.existsByMemberIdAndCertificateIdAndVerificationStatus(
+                memberId,
+                certificateId,
+                CertificateVerificationStatus.VERIFIED.name()
+        )) {
+            throw new InvalidCertificateUploadException("Certificate already verified for this member");
+        }
+    }
+
+    private BigDecimal defaultScore(BigDecimal score) {
+        return score == null ? BigDecimal.ZERO : score;
     }
 
     private void validateRequest(

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -1,44 +1,277 @@
 package com.nudgebank.bankbackend.certificate.service;
 
+import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.certificate.domain.CertificateIssuerAlias;
 import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
 import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
+import com.nudgebank.bankbackend.certificate.repository.CertificateIssuerAliasRepository;
 import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
-import org.springframework.stereotype.Service;
-
+import java.math.BigDecimal;
 import java.text.Normalizer;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
 
 @Service
 public class CertificateVerificationService {
 
-    private final CertificateMasterRepository certificateMasterRepository;
+    private static final Pattern NAME_PATTERN = Pattern.compile(
+            "(?:성\\s*명|이\\s*름)\\s*[:：]?\\s*([가-힣]{2,10})"
+    );
+    private static final Pattern NAME_FALLBACK_PATTERN = Pattern.compile(
+            "(?:성\\s*명|이\\s*름)\\s*[:：]?\\s*([가-힣\\s]{2,20})"
+    );
 
-    public CertificateVerificationService(CertificateMasterRepository certificateMasterRepository) {
+    private static final String[] PASS_KEYWORDS = {
+            "합격",
+            "합격증",
+            "합격증명서",
+            "취득",
+            "증명",
+            "확인",
+            "확인서",
+            "자격취득확인서",
+            "취특"
+    };
+
+    private static final String[] REJECTION_KEYWORDS = {
+            "예시",
+            "샘플",
+            "수험표",
+            "접수확인"
+    };
+
+    private final CertificateMasterRepository certificateMasterRepository;
+    private final CertificateIssuerAliasRepository certificateIssuerAliasRepository;
+
+    public CertificateVerificationService(
+            CertificateMasterRepository certificateMasterRepository,
+            CertificateIssuerAliasRepository certificateIssuerAliasRepository
+    ) {
         this.certificateMasterRepository = certificateMasterRepository;
+        this.certificateIssuerAliasRepository = certificateIssuerAliasRepository;
     }
 
-    public CertificateMatchResult verify(Long certificateId, String extractedText) {
+    public CertificateMatchResult verify(
+            Member member,
+            Long certificateId,
+            String extractedText,
+            List<String> extractedLines
+    ) {
         CertificateMaster certificateMaster = certificateMasterRepository.findByCertificateIdAndIsActiveTrue(certificateId)
                 .orElseThrow(() -> new CertificateVerificationException("Active certificate master not found"));
 
         String normalizedText = normalize(extractedText);
-        boolean certificateNameMatched = contains(normalizedText, certificateMaster.getCertificateName());
-        boolean issuerNameMatched = contains(normalizedText, certificateMaster.getIssuerName());
+        List<CertificateIssuerAlias> issuerAliases =
+                certificateIssuerAliasRepository.findAllByCertificateIdAndIsActiveTrue(certificateId);
 
-        if (certificateNameMatched && issuerNameMatched) {
+        String detectedName = detectName(extractedText, extractedLines);
+        boolean nameMatched = matchesName(member.getName(), detectedName, normalizedText);
+        boolean certificateNameMatched = contains(normalizedText, certificateMaster.getCertificateName())
+                || contains(normalizedText, certificateMaster.getCertificateNameEn());
+        String matchedIssuerName = findMatchedIssuerName(normalizedText, issuerAliases);
+        boolean issuerMatched = matchedIssuerName != null;
+        boolean passKeywordMatched = containsAny(normalizedText, PASS_KEYWORDS);
+        boolean rejectionKeywordMatched = containsAny(normalizedText, REJECTION_KEYWORDS);
+
+        BigDecimal score = BigDecimal.ZERO;
+        if (certificateNameMatched) {
+            score = score.add(BigDecimal.valueOf(40));
+        }
+        if (issuerMatched) {
+            score = score.add(BigDecimal.valueOf(30));
+        }
+        if (nameMatched) {
+            score = score.add(BigDecimal.valueOf(20));
+        }
+        if (passKeywordMatched) {
+            score = score.add(BigDecimal.valueOf(10));
+        }
+        if (rejectionKeywordMatched) {
+            score = score.subtract(BigDecimal.valueOf(100));
+        }
+
+        if (nameMatched && certificateNameMatched && issuerMatched && passKeywordMatched && !rejectionKeywordMatched) {
             return new CertificateMatchResult(
                     CertificateVerificationStatus.VERIFIED,
-                    OffsetDateTime.now()
+                    OffsetDateTime.now(),
+                    score,
+                    matchedIssuerName,
+                    detectedName,
+                    true,
+                    "VERIFIED"
             );
         }
 
         return new CertificateMatchResult(
                 CertificateVerificationStatus.VERIFICATION_FAILED,
-                null
+                null,
+                score,
+                matchedIssuerName,
+                detectedName,
+                nameMatched,
+                buildReviewNote(
+                        nameMatched,
+                        certificateNameMatched,
+                        issuerMatched,
+                        passKeywordMatched,
+                        rejectionKeywordMatched
+                )
         );
+    }
+
+    private String buildReviewNote(
+            boolean nameMatched,
+            boolean certificateNameMatched,
+            boolean issuerMatched,
+            boolean passKeywordMatched,
+            boolean rejectionKeywordMatched
+    ) {
+        if (!nameMatched) {
+            return "NAME_MISMATCH";
+        }
+        if (!certificateNameMatched) {
+            return "CERTIFICATE_NAME_MISMATCH";
+        }
+        if (!issuerMatched) {
+            return "ISSUER_MISMATCH";
+        }
+        if (!passKeywordMatched) {
+            return "PASS_KEYWORD_NOT_FOUND";
+        }
+        if (rejectionKeywordMatched) {
+            return "INVALID_DOCUMENT_TYPE";
+        }
+        return "VERIFICATION_FAILED";
+    }
+
+    private String findMatchedIssuerName(String normalizedText, List<CertificateIssuerAlias> issuerAliases) {
+        for (CertificateIssuerAlias issuerAlias : issuerAliases) {
+            if (matchesIssuer(normalizedText, issuerAlias.getIssuerName())
+                    || matchesIssuer(normalizedText, issuerAlias.getIssuerNameEn())) {
+                return issuerAlias.getIssuerName();
+            }
+        }
+        return null;
+    }
+
+    private boolean matchesIssuer(String normalizedText, String issuerName) {
+        if (contains(normalizedText, issuerName)) {
+            return true;
+        }
+
+        String normalizedIssuerName = normalize(issuerName);
+        if (normalizedIssuerName.isBlank()) {
+            return false;
+        }
+
+        return findApproximateMatch(normalizedText, normalizedIssuerName, 2);
+    }
+
+    private boolean matchesName(String memberName, String detectedName, String normalizedText) {
+        if (contains(normalizedText, memberName)) {
+            return true;
+        }
+
+        if (detectedName == null || detectedName.isBlank()) {
+            return false;
+        }
+
+        String normalizedMemberName = normalize(memberName);
+        String normalizedDetectedName = normalize(detectedName);
+
+        if (normalizedMemberName.equals(normalizedDetectedName)) {
+            return true;
+        }
+
+        return hasAllowedMismatch(normalizedMemberName, normalizedDetectedName, 1);
+    }
+
+    private boolean findApproximateMatch(String normalizedText, String expectedValue, int allowedMismatch) {
+        if (normalizedText.length() < expectedValue.length()) {
+            return false;
+        }
+
+        for (int start = 0; start <= normalizedText.length() - expectedValue.length(); start++) {
+            String candidate = normalizedText.substring(start, start + expectedValue.length());
+            if (hasAllowedMismatch(expectedValue, candidate, allowedMismatch)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean hasAllowedMismatch(String expectedValue, String actualValue, int allowedMismatch) {
+        if (expectedValue.isBlank() || actualValue.isBlank()) {
+            return false;
+        }
+
+        if (expectedValue.length() != actualValue.length()) {
+            return false;
+        }
+
+        int mismatchCount = 0;
+        for (int i = 0; i < expectedValue.length(); i++) {
+            if (expectedValue.charAt(i) != actualValue.charAt(i)) {
+                mismatchCount++;
+                if (mismatchCount > allowedMismatch) {
+                    return false;
+                }
+            }
+        }
+
+        return mismatchCount <= allowedMismatch;
+    }
+
+    private String detectName(String extractedText, List<String> extractedLines) {
+        if (extractedLines != null) {
+            for (String line : extractedLines) {
+                String detected = extractNameFromText(line);
+                if (detected != null) {
+                    return detected;
+                }
+            }
+        }
+
+        return extractNameFromText(extractedText);
+    }
+
+    private String extractNameFromText(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        Matcher matcher = NAME_PATTERN.matcher(value);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        Matcher fallbackMatcher = NAME_FALLBACK_PATTERN.matcher(value);
+        if (fallbackMatcher.find()) {
+            String candidate = fallbackMatcher.group(1)
+                    .replaceAll("\\s+", "")
+                    .replaceAll("[^가-힣]", "");
+            if (candidate.length() >= 2) {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean containsAny(String normalizedText, String... expectedValues) {
+        for (String expectedValue : expectedValues) {
+            if (contains(normalizedText, expectedValue)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean contains(String normalizedText, String expectedValue) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #23 

---

### 📝 작업 내용
- OCR 결과 기반 자격증 매칭 로직을 점수 기반 검증 구조로 보완했습니다.
- 자격증명과 발급기관 비교 시 OCR 오탈자를 고려할 수 있도록 이름/기관명 비교를 완화했습니다.
- 회원 이름 비교 시 한 글자 오차를 허용하도록 개선했습니다.
- 발급기관 매칭 시 등록된 기관명과 1~2글자 오차 범위를 허용하도록 보완했습니다.
- 합격/취득 관련 키워드 외에도 확인서 성격의 키워드를 인식하도록 보완했습니다.
- `certificate_issuer_alias` 기반 발급기관 검증 구조를 반영했습니다.
- 실패한 인증 건은 재업로드 가능하도록 중복 제출 차단 로직을 `VERIFIED` 상태 기준으로 변경했습니다.
---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
