### PR TITLE
Feat: 자격증 인증 실패 사유 응답 추가

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateMaster.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateMaster.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @Entity
@@ -23,14 +24,11 @@ public class CertificateMaster {
     @Column(name = "certificate_name", length = 200)
     private String certificateName;
 
-    @Column(name = "certificate_code", length = 50)
-    private String certificateCode;
+    @Column(name = "issuer_name", length = 200)
+    private String issuerName;
 
-    @Column(name = "certificate_name_en", length = 200)
-    private String certificateNameEn;
-
-    @Column(name = "certificate_category", length = 100)
-    private String certificateCategory;
+    @Column(name = "rate_discount")
+    private BigDecimal rateDiscount;
 
     @Column(name = "is_active")
     private Boolean isActive;

--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @Entity
@@ -46,7 +47,7 @@ public class CertificateSubmission {
     private String ocrText;
 
     @Column(name = "match_score", precision = 5, scale = 2)
-    private java.math.BigDecimal matchScore;
+    private BigDecimal matchScore;
 
     @Column(name = "detected_name", length = 100)
     private String detectedName;

--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateSubmission.java
@@ -12,7 +12,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @Entity
@@ -37,29 +36,14 @@ public class CertificateSubmission {
     @Column(name = "certificate_id", nullable = false)
     private Long certificateId;
 
-    @Column(name = "matched_issuer_name", length = 200)
-    private String matchedIssuerName;
-
     @Column(name = "file_url", length = 500)
     private String fileUrl;
 
     @Column(name = "ocr_text", columnDefinition = "TEXT")
     private String ocrText;
 
-    @Column(name = "match_score", precision = 5, scale = 2)
-    private BigDecimal matchScore;
-
-    @Column(name = "detected_name", length = 100)
-    private String detectedName;
-
-    @Column(name = "name_match_yn")
-    private Boolean nameMatchYn;
-
     @Column(name = "verification_status", length = 30)
     private String verificationStatus;
-
-    @Column(name = "review_note", length = 500)
-    private String reviewNote;
 
     @Column(name = "submitted_at")
     private OffsetDateTime submittedAt;

--- a/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
@@ -12,6 +12,7 @@ public record CertificateMatchResult(
         String matchedIssuerName,
         String detectedName,
         boolean nameMatched,
-        String reviewNote
+        String reviewNote,
+        String failureReason
 ) {
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateMatchResult.java
@@ -2,17 +2,11 @@ package com.nudgebank.bankbackend.certificate.dto;
 
 import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 public record CertificateMatchResult(
         CertificateVerificationStatus verificationStatus,
         OffsetDateTime verifiedAt,
-        BigDecimal matchScore,
-        String matchedIssuerName,
-        String detectedName,
-        boolean nameMatched,
-        String reviewNote,
         String failureReason
 ) {
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateSubmissionResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/dto/CertificateSubmissionResponse.java
@@ -11,6 +11,7 @@ public record CertificateSubmissionResponse(
         List<String> lines,
         int lineCount,
         String verificationStatus,
+        String failureReason,
         OffsetDateTime submittedAt
 ) {
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
@@ -3,7 +3,6 @@ package com.nudgebank.bankbackend.certificate.service;
 import com.nudgebank.bankbackend.auth.domain.Member;
 import com.nudgebank.bankbackend.auth.repository.MemberRepository;
 import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
-import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
 import com.nudgebank.bankbackend.certificate.repository.CertificateSubmissionRepository;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @Service
@@ -45,32 +43,24 @@ public class CertificateSubmissionService {
             MultipartFile file
     ) {
         validateRequest(memberId, loanId, certificateId, file);
-        validateDuplicateSubmission(memberId, certificateId);
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new InvalidCertificateUploadException("Member not found"));
 
         OcrExtractResponse ocrResponse = ocrClient.extract(file);
         OffsetDateTime submittedAt = OffsetDateTime.now();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new InvalidCertificateUploadException("Member not found"));
         CertificateMatchResult matchResult = certificateVerificationService.verify(
-                member,
                 certificateId,
                 ocrResponse.extractedText(),
-                ocrResponse.lines()
+                member
         );
 
         CertificateSubmission submission = CertificateSubmission.builder()
                 .memberId(memberId)
                 .loanApplicationId(loanId)
                 .certificateId(certificateId)
-                .matchedIssuerName(matchResult.matchedIssuerName())
                 .fileUrl(file.getOriginalFilename())
                 .ocrText(ocrResponse.extractedText())
-                .matchScore(defaultScore(matchResult.matchScore()))
-                .detectedName(matchResult.detectedName())
-                .nameMatchYn(matchResult.nameMatched())
                 .verificationStatus(matchResult.verificationStatus().name())
-                .reviewNote(matchResult.reviewNote())
                 .submittedAt(submittedAt)
                 .verifiedAt(matchResult.verifiedAt())
                 .build();
@@ -88,20 +78,6 @@ public class CertificateSubmissionService {
                 matchResult.failureReason(),
                 savedSubmission.getSubmittedAt()
         );
-    }
-
-    private void validateDuplicateSubmission(Long memberId, Long certificateId) {
-        if (certificateSubmissionRepository.existsByMemberIdAndCertificateIdAndVerificationStatus(
-                memberId,
-                certificateId,
-                CertificateVerificationStatus.VERIFIED.name()
-        )) {
-            throw new InvalidCertificateUploadException("Certificate already verified for this member");
-        }
-    }
-
-    private BigDecimal defaultScore(BigDecimal score) {
-        return score == null ? BigDecimal.ZERO : score;
     }
 
     private void validateRequest(

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
@@ -2,10 +2,10 @@ package com.nudgebank.bankbackend.certificate.service;
 
 import com.nudgebank.bankbackend.auth.domain.Member;
 import com.nudgebank.bankbackend.auth.repository.MemberRepository;
-import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
-import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
-import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
+import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
+import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
+import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
 import com.nudgebank.bankbackend.certificate.repository.CertificateSubmissionRepository;
 import com.nudgebank.bankbackend.ocr.client.OcrClient;
 import com.nudgebank.bankbackend.ocr.dto.OcrExtractResponse;
@@ -85,6 +85,7 @@ public class CertificateSubmissionService {
                 ocrResponse.lines(),
                 ocrResponse.lineCount(),
                 matchResult.verificationStatus().name(),
+                matchResult.failureReason(),
                 savedSubmission.getSubmittedAt()
         );
     }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -8,6 +8,8 @@ import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
 import com.nudgebank.bankbackend.certificate.repository.CertificateIssuerAliasRepository;
 import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
+import org.springframework.stereotype.Service;
+
 import java.math.BigDecimal;
 import java.text.Normalizer;
 import java.time.OffsetDateTime;
@@ -15,16 +17,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.springframework.stereotype.Service;
 
 @Service
 public class CertificateVerificationService {
 
     private static final Pattern NAME_PATTERN = Pattern.compile(
-            "(?:성\\s*명|이\\s*름)\\s*[:：]?\\s*([가-힣]{2,10})"
+            "(?:성\\s*명|이\\s*름)\\s*[:：`\"' ]*\\s*([가-힣]{2,10})"
     );
     private static final Pattern NAME_FALLBACK_PATTERN = Pattern.compile(
-            "(?:성\\s*명|이\\s*름)\\s*[:：]?\\s*([가-힣\\s]{2,20})"
+            "(?:성\\s*명|이\\s*름)\\s*[:：`\"' ]*\\s*([가-힣\\s]{2,20})"
     );
 
     private static final String[] PASS_KEYWORDS = {
@@ -66,6 +67,19 @@ public class CertificateVerificationService {
         CertificateMaster certificateMaster = certificateMasterRepository.findByCertificateIdAndIsActiveTrue(certificateId)
                 .orElseThrow(() -> new CertificateVerificationException("Active certificate master not found"));
 
+        if (extractedText == null || extractedText.isBlank()) {
+            return new CertificateMatchResult(
+                    CertificateVerificationStatus.VERIFICATION_FAILED,
+                    null,
+                    BigDecimal.ZERO,
+                    null,
+                    null,
+                    false,
+                    "OCR_TEXT_NOT_DETECTED",
+                    "OCR_TEXT_NOT_DETECTED"
+            );
+        }
+
         String normalizedText = normalize(extractedText);
         List<CertificateIssuerAlias> issuerAliases =
                 certificateIssuerAliasRepository.findAllByCertificateIdAndIsActiveTrue(certificateId);
@@ -104,9 +118,18 @@ public class CertificateVerificationService {
                     matchedIssuerName,
                     detectedName,
                     true,
-                    "VERIFIED"
+                    "VERIFIED",
+                    null
             );
         }
+
+        String failureReason = buildFailureReason(
+                nameMatched,
+                certificateNameMatched,
+                issuerMatched,
+                passKeywordMatched,
+                rejectionKeywordMatched
+        );
 
         return new CertificateMatchResult(
                 CertificateVerificationStatus.VERIFICATION_FAILED,
@@ -115,17 +138,12 @@ public class CertificateVerificationService {
                 matchedIssuerName,
                 detectedName,
                 nameMatched,
-                buildReviewNote(
-                        nameMatched,
-                        certificateNameMatched,
-                        issuerMatched,
-                        passKeywordMatched,
-                        rejectionKeywordMatched
-                )
+                failureReason,
+                failureReason
         );
     }
 
-    private String buildReviewNote(
+    private String buildFailureReason(
             boolean nameMatched,
             boolean certificateNameMatched,
             boolean issuerMatched,
@@ -139,7 +157,7 @@ public class CertificateVerificationService {
             return "CERTIFICATE_NAME_MISMATCH";
         }
         if (!issuerMatched) {
-            return "ISSUER_MISMATCH";
+            return "ISSUER_NAME_MISMATCH";
         }
         if (!passKeywordMatched) {
             return "PASS_KEYWORD_NOT_FOUND";
@@ -177,14 +195,12 @@ public class CertificateVerificationService {
         if (contains(normalizedText, memberName)) {
             return true;
         }
-
         if (detectedName == null || detectedName.isBlank()) {
             return false;
         }
 
         String normalizedMemberName = normalize(memberName);
         String normalizedDetectedName = normalize(detectedName);
-
         if (normalizedMemberName.equals(normalizedDetectedName)) {
             return true;
         }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -1,19 +1,15 @@
 package com.nudgebank.bankbackend.certificate.service;
 
 import com.nudgebank.bankbackend.auth.domain.Member;
-import com.nudgebank.bankbackend.certificate.domain.CertificateIssuerAlias;
 import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
 import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
-import com.nudgebank.bankbackend.certificate.repository.CertificateIssuerAliasRepository;
 import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
 import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
 import java.text.Normalizer;
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,46 +20,20 @@ public class CertificateVerificationService {
     private static final Pattern NAME_PATTERN = Pattern.compile(
             "(?:성\\s*명|이\\s*름)\\s*[:：`\"' ]*\\s*([가-힣]{2,10})"
     );
-    private static final Pattern NAME_FALLBACK_PATTERN = Pattern.compile(
-            "(?:성\\s*명|이\\s*름)\\s*[:：`\"' ]*\\s*([가-힣\\s]{2,20})"
-    );
-
     private static final String[] PASS_KEYWORDS = {
-            "합격",
-            "합격증",
-            "합격증명서",
-            "취득",
-            "증명",
-            "확인",
-            "확인서",
-            "자격취득확인서",
-            "취특"
+            "합격", "합격증", "합격증명서", "취득", "증명", "확인", "확인서"
     };
-
-    private static final String[] REJECTION_KEYWORDS = {
-            "예시",
-            "샘플",
-            "수험표",
-            "접수확인"
+    private static final String[] INVALID_DOCUMENT_KEYWORDS = {
+            "예시", "샘플", "수험표", "접수확인"
     };
 
     private final CertificateMasterRepository certificateMasterRepository;
-    private final CertificateIssuerAliasRepository certificateIssuerAliasRepository;
 
-    public CertificateVerificationService(
-            CertificateMasterRepository certificateMasterRepository,
-            CertificateIssuerAliasRepository certificateIssuerAliasRepository
-    ) {
+    public CertificateVerificationService(CertificateMasterRepository certificateMasterRepository) {
         this.certificateMasterRepository = certificateMasterRepository;
-        this.certificateIssuerAliasRepository = certificateIssuerAliasRepository;
     }
 
-    public CertificateMatchResult verify(
-            Member member,
-            Long certificateId,
-            String extractedText,
-            List<String> extractedLines
-    ) {
+    public CertificateMatchResult verify(Long certificateId, String extractedText, Member member) {
         CertificateMaster certificateMaster = certificateMasterRepository.findByCertificateIdAndIsActiveTrue(certificateId)
                 .orElseThrow(() -> new CertificateVerificationException("Active certificate master not found"));
 
@@ -71,54 +41,22 @@ public class CertificateVerificationService {
             return new CertificateMatchResult(
                     CertificateVerificationStatus.VERIFICATION_FAILED,
                     null,
-                    BigDecimal.ZERO,
-                    null,
-                    null,
-                    false,
-                    "OCR_TEXT_NOT_DETECTED",
                     "OCR_TEXT_NOT_DETECTED"
             );
         }
 
         String normalizedText = normalize(extractedText);
-        List<CertificateIssuerAlias> issuerAliases =
-                certificateIssuerAliasRepository.findAllByCertificateIdAndIsActiveTrue(certificateId);
-
-        String detectedName = detectName(extractedText, extractedLines);
+        String detectedName = extractName(extractedText);
         boolean nameMatched = matchesName(member.getName(), detectedName, normalizedText);
-        boolean certificateNameMatched = contains(normalizedText, certificateMaster.getCertificateName())
-                || contains(normalizedText, certificateMaster.getCertificateNameEn());
-        String matchedIssuerName = findMatchedIssuerName(normalizedText, issuerAliases);
-        boolean issuerMatched = matchedIssuerName != null;
+        boolean certificateNameMatched = contains(normalizedText, certificateMaster.getCertificateName());
+        boolean issuerNameMatched = contains(normalizedText, certificateMaster.getIssuerName());
         boolean passKeywordMatched = containsAny(normalizedText, PASS_KEYWORDS);
-        boolean rejectionKeywordMatched = containsAny(normalizedText, REJECTION_KEYWORDS);
+        boolean invalidDocumentMatched = containsAny(normalizedText, INVALID_DOCUMENT_KEYWORDS);
 
-        BigDecimal score = BigDecimal.ZERO;
-        if (certificateNameMatched) {
-            score = score.add(BigDecimal.valueOf(40));
-        }
-        if (issuerMatched) {
-            score = score.add(BigDecimal.valueOf(30));
-        }
-        if (nameMatched) {
-            score = score.add(BigDecimal.valueOf(20));
-        }
-        if (passKeywordMatched) {
-            score = score.add(BigDecimal.valueOf(10));
-        }
-        if (rejectionKeywordMatched) {
-            score = score.subtract(BigDecimal.valueOf(100));
-        }
-
-        if (nameMatched && certificateNameMatched && issuerMatched && passKeywordMatched && !rejectionKeywordMatched) {
+        if (nameMatched && certificateNameMatched && issuerNameMatched && passKeywordMatched && !invalidDocumentMatched) {
             return new CertificateMatchResult(
                     CertificateVerificationStatus.VERIFIED,
                     OffsetDateTime.now(),
-                    score,
-                    matchedIssuerName,
-                    detectedName,
-                    true,
-                    "VERIFIED",
                     null
             );
         }
@@ -126,19 +64,14 @@ public class CertificateVerificationService {
         String failureReason = buildFailureReason(
                 nameMatched,
                 certificateNameMatched,
-                issuerMatched,
+                issuerNameMatched,
                 passKeywordMatched,
-                rejectionKeywordMatched
+                invalidDocumentMatched
         );
 
         return new CertificateMatchResult(
                 CertificateVerificationStatus.VERIFICATION_FAILED,
                 null,
-                score,
-                matchedIssuerName,
-                detectedName,
-                nameMatched,
-                failureReason,
                 failureReason
         );
     }
@@ -146,9 +79,9 @@ public class CertificateVerificationService {
     private String buildFailureReason(
             boolean nameMatched,
             boolean certificateNameMatched,
-            boolean issuerMatched,
+            boolean issuerNameMatched,
             boolean passKeywordMatched,
-            boolean rejectionKeywordMatched
+            boolean invalidDocumentMatched
     ) {
         if (!nameMatched) {
             return "NAME_MISMATCH";
@@ -156,39 +89,25 @@ public class CertificateVerificationService {
         if (!certificateNameMatched) {
             return "CERTIFICATE_NAME_MISMATCH";
         }
-        if (!issuerMatched) {
+        if (!issuerNameMatched) {
             return "ISSUER_NAME_MISMATCH";
         }
         if (!passKeywordMatched) {
             return "PASS_KEYWORD_NOT_FOUND";
         }
-        if (rejectionKeywordMatched) {
+        if (invalidDocumentMatched) {
             return "INVALID_DOCUMENT_TYPE";
         }
         return "VERIFICATION_FAILED";
     }
 
-    private String findMatchedIssuerName(String normalizedText, List<CertificateIssuerAlias> issuerAliases) {
-        for (CertificateIssuerAlias issuerAlias : issuerAliases) {
-            if (matchesIssuer(normalizedText, issuerAlias.getIssuerName())
-                    || matchesIssuer(normalizedText, issuerAlias.getIssuerNameEn())) {
-                return issuerAlias.getIssuerName();
-            }
-        }
-        return null;
-    }
-
-    private boolean matchesIssuer(String normalizedText, String issuerName) {
-        if (contains(normalizedText, issuerName)) {
-            return true;
+    private String extractName(String extractedText) {
+        Matcher matcher = NAME_PATTERN.matcher(extractedText);
+        if (!matcher.find()) {
+            return null;
         }
 
-        String normalizedIssuerName = normalize(issuerName);
-        if (normalizedIssuerName.isBlank()) {
-            return false;
-        }
-
-        return findApproximateMatch(normalizedText, normalizedIssuerName, 2);
+        return matcher.group(1);
     }
 
     private boolean matchesName(String memberName, String detectedName, String normalizedText) {
@@ -205,85 +124,30 @@ public class CertificateVerificationService {
             return true;
         }
 
-        return hasAllowedMismatch(normalizedMemberName, normalizedDetectedName, 1);
+        return hasSingleCharacterMismatch(normalizedMemberName, normalizedDetectedName);
     }
 
-    private boolean findApproximateMatch(String normalizedText, String expectedValue, int allowedMismatch) {
-        if (normalizedText.length() < expectedValue.length()) {
-            return false;
-        }
-
-        for (int start = 0; start <= normalizedText.length() - expectedValue.length(); start++) {
-            String candidate = normalizedText.substring(start, start + expectedValue.length());
-            if (hasAllowedMismatch(expectedValue, candidate, allowedMismatch)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private boolean hasAllowedMismatch(String expectedValue, String actualValue, int allowedMismatch) {
-        if (expectedValue.isBlank() || actualValue.isBlank()) {
-            return false;
-        }
-
-        if (expectedValue.length() != actualValue.length()) {
+    private boolean hasSingleCharacterMismatch(String expected, String actual) {
+        if (expected.length() != actual.length() || expected.isBlank()) {
             return false;
         }
 
         int mismatchCount = 0;
-        for (int i = 0; i < expectedValue.length(); i++) {
-            if (expectedValue.charAt(i) != actualValue.charAt(i)) {
+        for (int i = 0; i < expected.length(); i++) {
+            if (expected.charAt(i) != actual.charAt(i)) {
                 mismatchCount++;
-                if (mismatchCount > allowedMismatch) {
+                if (mismatchCount > 1) {
                     return false;
                 }
             }
         }
 
-        return mismatchCount <= allowedMismatch;
+        return mismatchCount == 1;
     }
 
-    private String detectName(String extractedText, List<String> extractedLines) {
-        if (extractedLines != null) {
-            for (String line : extractedLines) {
-                String detected = extractNameFromText(line);
-                if (detected != null) {
-                    return detected;
-                }
-            }
-        }
-
-        return extractNameFromText(extractedText);
-    }
-
-    private String extractNameFromText(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-
-        Matcher matcher = NAME_PATTERN.matcher(value);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-
-        Matcher fallbackMatcher = NAME_FALLBACK_PATTERN.matcher(value);
-        if (fallbackMatcher.find()) {
-            String candidate = fallbackMatcher.group(1)
-                    .replaceAll("\\s+", "")
-                    .replaceAll("[^가-힣]", "");
-            if (candidate.length() >= 2) {
-                return candidate;
-            }
-        }
-
-        return null;
-    }
-
-    private boolean containsAny(String normalizedText, String... expectedValues) {
-        for (String expectedValue : expectedValues) {
-            if (contains(normalizedText, expectedValue)) {
+    private boolean containsAny(String normalizedText, String... values) {
+        for (String value : values) {
+            if (contains(normalizedText, value)) {
                 return true;
             }
         }

--- a/src/main/java/com/nudgebank/bankbackend/chatbot/service/UserService.java
+++ b/src/main/java/com/nudgebank/bankbackend/chatbot/service/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
 
     public Map<String, Object> getUserInfo(String userId) {
 
-        Member user = memberRepository.findById(userId)
+        Member user = memberRepository.findByLoginId(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         Map<String, Object> result = new HashMap<>();


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #31 

---

### 📝 작업 내용
- 자격증 인증 결과 응답에 `failureReason` 필드를 추가했습니다.
- OCR 검증 실패 시 프론트에서 활용할 수 있도록 실패 사유 코드를 구조화했습니다.
- 이름 불일치, 자격증명 불일치, 발급기관 불일치, 합격 문구 미검출, 문서 부적합, OCR 텍스트 미검출 케이스를 구분하도록 보완했습니다.
- 자격증 제출 응답 DTO와 매칭 결과 DTO를 함께 정리했습니다.
- 현재 DB 스키마와의 호환을 위해 제출 저장 시 `loanId` 값을 함께 반영하도록 조정했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 인증서 검증 결과에 상세한 실패 사유(failureReason) 포함

* **버그 수정**
  * OCR 미감지 시 즉시 실패 처리로 불완전한 업로드 대응 개선
  * 중복 검증 관련 일부 예외 경로 제거로 제출 흐름 변경

* **개선 사항**
  * 이름 및 발급기관 매칭 로직 간소화로 검증 일관성 향상
  * 응답 항목 구성 조정(일부 내부 매칭 메타데이터 제거)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->