### PR TITLE
Feat: 카드 거래 기준 재무 상태 조회 api 구현

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
+++ b/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
@@ -80,6 +80,13 @@ public class Account {
       throw new IllegalStateException("계좌 잔액 정보가 없습니다.");
     }
 
+    BigDecimal availableBalance = this.balance.subtract(
+      this.protectedBalance != null ? this.protectedBalance : BigDecimal.ZERO
+    );
+    if (availableBalance.compareTo(amount) < 0) {
+      throw new IllegalStateException("사용 가능 잔액이 부족합니다.");
+    }
+
     this.balance = this.balance.subtract(amount);
   }
 }

--- a/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
+++ b/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
@@ -1,16 +1,11 @@
 package com.nudgebank.bankbackend.account.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.math.BigDecimal;
-import java.time.OffsetDateTime;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.AccessLevel;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "account")
@@ -75,5 +70,16 @@ public class Account {
         openedAt,
         protectedBalance
     );
+  }
+  public void withdraw(BigDecimal amount) {
+    if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new IllegalArgumentException("차감 금액은 0보다 커야 합니다.");
+    }
+
+    if (this.balance == null) {
+      throw new IllegalStateException("계좌 잔액 정보가 없습니다.");
+    }
+
+    this.balance = this.balance.subtract(amount);
   }
 }

--- a/src/main/java/com/nudgebank/bankbackend/account/repository/AccountRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/account/repository/AccountRepository.java
@@ -1,12 +1,10 @@
 package com.nudgebank.bankbackend.account.repository;
 
 import com.nudgebank.bankbackend.account.domain.Account;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
   boolean existsByAccountNumber(String accountNumber);
-  Optional<Account> findByMemberId(Long memberId);
   List<Account> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/account/repository/AccountRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/account/repository/AccountRepository.java
@@ -1,10 +1,20 @@
 package com.nudgebank.bankbackend.account.repository;
 
 import com.nudgebank.bankbackend.account.domain.Account;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
   boolean existsByAccountNumber(String accountNumber);
   List<Account> findAllByMemberId(Long memberId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select a from Account a where a.accountId = :accountId")
+  Optional<Account> findByIdForUpdate(@Param("accountId") Long accountId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.nudgebank.bankbackend.auth.config;
 
 import com.nudgebank.bankbackend.auth.security.JwtAuthFilter;
 import com.nudgebank.bankbackend.auth.security.JwtProvider;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -17,6 +16,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
 @Configuration
 @EnableMethodSecurity
 @EnableWebSecurity
@@ -37,6 +37,8 @@ public class SecurityConfig {
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/auth/**").permitAll()
+            .requestMatchers("/api/cards/payment").authenticated()
+            .requestMatchers("/api/finance-status/**").authenticated()
             .anyRequest().permitAll()
         );
 

--- a/src/main/java/com/nudgebank/bankbackend/auth/security/SecurityUtil.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/security/SecurityUtil.java
@@ -1,0 +1,26 @@
+package com.nudgebank.bankbackend.auth.security;
+
+import org.springframework.security.core.Authentication;
+
+public final class SecurityUtil {
+    private SecurityUtil() {
+    }
+
+    public static Long extractUserId(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Long userId) {
+            return userId;
+        }
+        if (principal instanceof String str) {
+            try {
+                return Long.valueOf(str);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/controller/CardController.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/controller/CardController.java
@@ -5,15 +5,13 @@ import com.nudgebank.bankbackend.card.dto.CardIssueRequest;
 import com.nudgebank.bankbackend.card.dto.CardIssueResponse;
 import com.nudgebank.bankbackend.card.service.CardHistoryService;
 import com.nudgebank.bankbackend.card.service.CardIssueService;
-import java.util.List;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/cards")
@@ -31,9 +29,7 @@ public class CardController {
       @RequestBody CardIssueRequest request,
       Authentication authentication
   ) {
-    Long userId = authentication != null && authentication.getPrincipal() instanceof Long principal
-        ? principal
-        : null;
+    Long userId = extractUserId(authentication);
 
     try {
       return ResponseEntity.ok(cardIssueService.issue(userId, request));
@@ -43,6 +39,9 @@ public class CardController {
           : HttpStatus.BAD_REQUEST;
       return ResponseEntity.status(status)
           .body(new CardIssueResponse(false, ex.getMessage(), null, null, null, null, null, null, null, null, null));
+    } catch (EntityNotFoundException ex) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND)
+          .body(new CardIssueResponse(false, ex.getMessage(), null, null, null, null, null, null, null, null, null));
     } catch (IllegalStateException ex) {
       return ResponseEntity.status(HttpStatus.CONFLICT)
           .body(new CardIssueResponse(false, ex.getMessage(), null, null, null, null, null, null, null, null, null));
@@ -51,9 +50,7 @@ public class CardController {
 
   @GetMapping("/history")
   public ResponseEntity<CardHistoryResponse> history(Authentication authentication) {
-    Long userId = authentication != null && authentication.getPrincipal() instanceof Long principal
-        ? principal
-        : null;
+    Long userId = extractUserId(authentication);
 
     try {
       return ResponseEntity.ok(cardHistoryService.getHistory(userId));
@@ -63,6 +60,18 @@ public class CardController {
           : HttpStatus.BAD_REQUEST;
       return ResponseEntity.status(status)
           .body(new CardHistoryResponse(false, ex.getMessage(), List.of()));
+    } catch (EntityNotFoundException ex) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND)
+              .body(new CardHistoryResponse(false, ex.getMessage(), List.of()));
     }
+  }
+
+  private Long extractUserId(Authentication authentication) {
+    if (authentication == null) {
+      return null;
+}
+
+    Object principal = authentication.getPrincipal();
+    return principal instanceof Long ? (Long) principal : null;
   }
 }

--- a/src/main/java/com/nudgebank/bankbackend/card/controller/CardPaymentController.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/controller/CardPaymentController.java
@@ -1,0 +1,23 @@
+package com.nudgebank.bankbackend.card.controller;
+
+import com.nudgebank.bankbackend.card.dto.CardPaymentRequest;
+import com.nudgebank.bankbackend.card.service.CardPaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cards")
+public class CardPaymentController {
+
+    private final CardPaymentService cardPaymentService;
+
+    @PostMapping("/payment")
+    public ResponseEntity<Map<String, Long>> pay(@RequestBody CardPaymentRequest request) {
+        Long transactionId = cardPaymentService.processPayment(request);
+        return ResponseEntity.ok(Map.of("transactionId", transactionId));
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/controller/CardPaymentController.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/controller/CardPaymentController.java
@@ -1,10 +1,17 @@
 package com.nudgebank.bankbackend.card.controller;
 
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
 import com.nudgebank.bankbackend.card.dto.CardPaymentRequest;
 import com.nudgebank.bankbackend.card.service.CardPaymentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Map;
 
@@ -16,7 +23,14 @@ public class CardPaymentController {
     private final CardPaymentService cardPaymentService;
 
     @PostMapping("/payment")
-    public ResponseEntity<Map<String, Long>> pay(@RequestBody CardPaymentRequest request) {
+    public ResponseEntity<Map<String, Long>> pay(
+            @RequestBody CardPaymentRequest request,
+            Authentication authentication
+    ) {
+        Long userId = SecurityUtil.extractUserId(authentication);
+        if (userId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
         Long transactionId = cardPaymentService.processPayment(request);
         return ResponseEntity.ok(Map.of("transactionId", transactionId));
     }

--- a/src/main/java/com/nudgebank/bankbackend/card/domain/CardTransaction.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/domain/CardTransaction.java
@@ -1,23 +1,17 @@
 package com.nudgebank.bankbackend.card.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "card_transaction")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class CardTransaction {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/nudgebank/bankbackend/card/dto/CardPaymentRequest.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/dto/CardPaymentRequest.java
@@ -1,0 +1,14 @@
+package com.nudgebank.bankbackend.card.dto;
+
+import java.math.BigDecimal;
+
+public record CardPaymentRequest(
+        Long cardId,
+        Long marketId,
+        Long categoryId,
+        String qrId,
+        BigDecimal amount,
+        String menuName,
+        Integer quantity
+) {
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/repository/CardRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/repository/CardRepository.java
@@ -1,8 +1,8 @@
 package com.nudgebank.bankbackend.card.repository;
 
 import com.nudgebank.bankbackend.card.domain.Card;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
   boolean existsByCardNumber(String cardNumber);

--- a/src/main/java/com/nudgebank/bankbackend/card/repository/CardTransactionRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/repository/CardTransactionRepository.java
@@ -1,10 +1,14 @@
 package com.nudgebank.bankbackend.card.repository;
 
 import com.nudgebank.bankbackend.card.domain.CardTransaction;
-import java.time.OffsetDateTime;
-import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface CardTransactionRepository extends JpaRepository<CardTransaction, Long> {
   @EntityGraph(attributePaths = {"market", "category"})
@@ -14,5 +18,27 @@ public interface CardTransactionRepository extends JpaRepository<CardTransaction
       Long cardId,
       OffsetDateTime start,
       OffsetDateTime end
+  );
+
+  @Query("""
+        select coalesce(sum(ct.amount), 0)
+        from CardTransaction ct
+        where ct.card.cardId = :cardId
+          and ct.transactionDatetime >= :startOfMonth
+          and ct.transactionDatetime < :startOfNextMonth
+          and (
+                ct.transactionDatetime < :transactionDatetime
+                or (
+                    ct.transactionDatetime = :transactionDatetime
+                    and ct.transactionId <= :transactionId
+                )
+              )
+    """)
+  BigDecimal sumCurrentMonthSpendingAmountUntilTransaction(
+          @Param("cardId") Long cardId,
+          @Param("startOfMonth") OffsetDateTime startOfMonth,
+          @Param("startOfNextMonth") OffsetDateTime startOfNextMonth,
+          @Param("transactionDatetime") OffsetDateTime transactionDatetime,
+          @Param("transactionId") Long transactionId
   );
 }

--- a/src/main/java/com/nudgebank/bankbackend/card/repository/MarketCategoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/repository/MarketCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.nudgebank.bankbackend.card.repository;
+
+import com.nudgebank.bankbackend.card.domain.MarketCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketCategoryRepository extends JpaRepository<MarketCategory, Long> {
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/repository/MarketRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/repository/MarketRepository.java
@@ -1,0 +1,7 @@
+package com.nudgebank.bankbackend.card.repository;
+
+import com.nudgebank.bankbackend.card.domain.Market;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketRepository extends JpaRepository<Market, Long> {
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
@@ -38,7 +38,7 @@ public class CardPaymentService {
                         "카드를 찾을 수 없습니다. cardId=" + request.cardId()
                 ));
 
-        Account account = accountRepository.findById(card.getAccountId())
+        Account account = accountRepository.findByIdForUpdate(card.getAccountId())
                 .orElseThrow(() -> new EntityNotFoundException(
                         "카드에 연결된 계좌를 찾을 수 없습니다. accountId=" + card.getAccountId()
                 ));

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
@@ -1,0 +1,105 @@
+package com.nudgebank.bankbackend.card.service;
+
+import com.nudgebank.bankbackend.account.domain.Account;
+import com.nudgebank.bankbackend.account.repository.AccountRepository;
+import com.nudgebank.bankbackend.card.domain.Card;
+import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import com.nudgebank.bankbackend.card.domain.Market;
+import com.nudgebank.bankbackend.card.domain.MarketCategory;
+import com.nudgebank.bankbackend.card.dto.CardPaymentRequest;
+import com.nudgebank.bankbackend.card.repository.CardRepository;
+import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
+import com.nudgebank.bankbackend.card.repository.MarketCategoryRepository;
+import com.nudgebank.bankbackend.card.repository.MarketRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CardPaymentService {
+
+    private final CardRepository cardRepository;
+    private final AccountRepository accountRepository;
+    private final MarketRepository marketRepository;
+    private final MarketCategoryRepository marketCategoryRepository;
+    private final CardTransactionRepository cardTransactionRepository;
+
+    public Long processPayment(CardPaymentRequest request) {
+        validateRequest(request);
+
+        Card card = cardRepository.findById(request.cardId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "카드를 찾을 수 없습니다. cardId=" + request.cardId()
+                ));
+
+        Account account = accountRepository.findById(card.getAccountId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "카드에 연결된 계좌를 찾을 수 없습니다. accountId=" + card.getAccountId()
+                ));
+
+        Market market = marketRepository.findById(request.marketId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "가맹점을 찾을 수 없습니다. marketId=" + request.marketId()
+                ));
+
+        MarketCategory category = marketCategoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "카테고리를 찾을 수 없습니다. categoryId=" + request.categoryId()
+                ));
+
+        BigDecimal balance = nullSafe(account.getBalance());
+        BigDecimal protectedBalance = nullSafe(account.getProtectedBalance());
+        BigDecimal availableBalance = balance.subtract(protectedBalance);
+
+        if (availableBalance.compareTo(request.amount()) < 0) {
+            throw new IllegalArgumentException("잔액이 부족합니다.");
+        }
+
+        account.withdraw(request.amount());
+
+        CardTransaction transaction = CardTransaction.builder()
+                .card(card)
+                .market(market)
+                .category(category)
+                .qrId(request.qrId())
+                .amount(request.amount())
+                .transactionDatetime(OffsetDateTime.now())
+                .menuName(request.menuName())
+                .quantity(request.quantity())
+                .build();
+
+        CardTransaction saved = cardTransactionRepository.save(transaction);
+        return saved.getTransactionId();
+    }
+
+    private void validateRequest(CardPaymentRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("요청값이 없습니다.");
+        }
+        if (request.cardId() == null) {
+            throw new IllegalArgumentException("cardId는 필수입니다.");
+        }
+        if (request.marketId() == null) {
+            throw new IllegalArgumentException("marketId는 필수입니다.");
+        }
+        if (request.categoryId() == null) {
+            throw new IllegalArgumentException("categoryId는 필수입니다.");
+        }
+        if (request.qrId() == null || request.qrId().isBlank()) {
+            throw new IllegalArgumentException("qrId는 필수입니다.");
+        }
+        if (request.amount() == null || request.amount().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("amount는 0보다 커야 합니다.");
+        }
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/controller/FinancialStatusController.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/controller/FinancialStatusController.java
@@ -1,0 +1,22 @@
+package com.nudgebank.bankbackend.finance.controller;
+
+import com.nudgebank.bankbackend.finance.dto.FinancialStatusResponse;
+import com.nudgebank.bankbackend.finance.service.FinancialStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/finance-status")
+public class FinancialStatusController {
+
+    private final FinancialStatusService financialStatusService;
+
+    @GetMapping("/{memberId}/transaction/{transactionId}")
+    public FinancialStatusResponse getFinancialStatus(
+            @PathVariable Long memberId,
+            @PathVariable Long transactionId
+    ) {
+        return financialStatusService.getFinancialStatus(memberId, transactionId);
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/controller/FinancialStatusController.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/controller/FinancialStatusController.java
@@ -1,9 +1,16 @@
 package com.nudgebank.bankbackend.finance.controller;
 
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
 import com.nudgebank.bankbackend.finance.dto.FinancialStatusResponse;
 import com.nudgebank.bankbackend.finance.service.FinancialStatusService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,11 +19,15 @@ public class FinancialStatusController {
 
     private final FinancialStatusService financialStatusService;
 
-    @GetMapping("/{memberId}/transaction/{transactionId}")
+    @GetMapping("/transaction/{transactionId}")
     public FinancialStatusResponse getFinancialStatus(
-            @PathVariable Long memberId,
-            @PathVariable Long transactionId
+            @PathVariable Long transactionId,
+            Authentication authentication
     ) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
         return financialStatusService.getFinancialStatus(memberId, transactionId);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/finance/dto/FinancialStatusResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/dto/FinancialStatusResponse.java
@@ -1,0 +1,31 @@
+package com.nudgebank.bankbackend.finance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class FinancialStatusResponse {
+
+    private Long memberId;
+    private Long cardId;
+    private Long accountId;
+
+    // 자산/현금흐름
+    private BigDecimal linkedAccountBalance; //연동 계좌 잔액
+    private BigDecimal protectedBalance; //보호 잔액
+    private BigDecimal availableBalance; //사용 가능한 잔액
+    private BigDecimal monthlyIncome;    //월 소득
+    private Integer salaryDate;          //급여일
+
+    // 대출 상태
+    private BigDecimal totalLoanRemainingPrincipal; //총 대출 잔액
+    private BigDecimal monthlyRepaidAmount;        //이번 달 누적 상환 금액
+    private BigDecimal monthlyRemainingRepaymentAmount; //이번 달 남은 상환 금액
+    private Integer daysUntilPaymentDue;           //상환 예정일까지 남은 일 수
+
+    // 소비 상태
+    private BigDecimal currentMonthSpendingAmount; //이번 달 누적 지출 금액
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/FinancialStatusService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/FinancialStatusService.java
@@ -1,0 +1,165 @@
+package com.nudgebank.bankbackend.finance.service;
+
+import com.nudgebank.bankbackend.account.domain.Account;
+import com.nudgebank.bankbackend.account.repository.AccountRepository;
+import com.nudgebank.bankbackend.auth.repository.MemberRepository;
+import com.nudgebank.bankbackend.card.domain.Card;
+import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
+import com.nudgebank.bankbackend.finance.dto.FinancialStatusResponse;
+import com.nudgebank.bankbackend.loan.domain.LoanApplication;
+import com.nudgebank.bankbackend.loan.domain.LoanHistory;
+import com.nudgebank.bankbackend.loan.repository.LoanApplicationRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanHistoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FinancialStatusService {
+
+    private final MemberRepository memberRepository;
+    private final AccountRepository accountRepository;
+    private final CardTransactionRepository cardTransactionRepository;
+    private final LoanHistoryRepository loanHistoryRepository;
+    private final LoanApplicationRepository loanApplicationRepository;
+
+    public FinancialStatusResponse getFinancialStatus(Long memberId, Long transactionId) {
+        validateMemberExists(memberId);
+
+        CardTransaction transaction = cardTransactionRepository.findById(transactionId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "존재하지 않는 거래입니다. transactionId=" + transactionId
+                ));
+
+        Card card = transaction.getCard();
+
+        Account account = accountRepository.findById(card.getAccountId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "카드에 연결된 계좌가 없습니다. accountId=" + card.getAccountId()
+                ));
+
+        validateTransactionOwnership(memberId, account);
+
+        BigDecimal linkedAccountBalance = nullSafe(account.getBalance());
+        BigDecimal protectedBalance = nullSafe(account.getProtectedBalance());
+        BigDecimal availableBalance = calculateAvailableBalance(linkedAccountBalance, protectedBalance);
+
+        LoanHistory loanHistory = loanHistoryRepository
+                .findByCard_CardIdAndStatus(card.getCardId(), "ACTIVE")
+                .orElse(null);
+
+        BigDecimal totalLoanRemainingPrincipal = loanHistory != null
+                ? nullSafe(loanHistory.getRemainingPrincipal())
+                : BigDecimal.ZERO;
+
+        LoanApplication latestLoanApplication = loanApplicationRepository
+                .findTopByMember_MemberIdOrderByAppliedAtDesc(memberId)
+                .orElse(null);
+
+        BigDecimal monthlyIncome = latestLoanApplication != null
+                ? nullSafe(latestLoanApplication.getMonthlyIncome())
+                : BigDecimal.ZERO;
+
+        Integer salaryDate = latestLoanApplication != null
+                ? latestLoanApplication.getSalaryDate()
+                : null;
+
+        Integer daysUntilPaymentDue = calculateDaysUntilPaymentDue(loanHistory);
+
+        BigDecimal currentMonthSpendingAmount = nullSafe(
+                cardTransactionRepository.sumCurrentMonthSpendingAmountUntilTransaction(
+                        card.getCardId(),
+                        getStartOfMonth(transaction.getTransactionDatetime()),
+                        getStartOfNextMonth(transaction.getTransactionDatetime()),
+                        transaction.getTransactionDatetime(),
+                        transaction.getTransactionId()
+                )
+        );
+
+        BigDecimal monthlyRepaidAmount = BigDecimal.ZERO;
+        BigDecimal monthlyRemainingRepaymentAmount = BigDecimal.ZERO;
+
+        return FinancialStatusResponse.builder()
+                .memberId(memberId)
+                .cardId(card.getCardId())
+                .accountId(account.getAccountId())
+                .linkedAccountBalance(linkedAccountBalance)
+                .protectedBalance(protectedBalance)
+                .availableBalance(availableBalance)
+                .monthlyIncome(monthlyIncome)
+                .salaryDate(salaryDate)
+                .totalLoanRemainingPrincipal(totalLoanRemainingPrincipal)
+                .monthlyRepaidAmount(monthlyRepaidAmount)
+                .monthlyRemainingRepaymentAmount(monthlyRemainingRepaymentAmount)
+                .daysUntilPaymentDue(daysUntilPaymentDue)
+                .currentMonthSpendingAmount(currentMonthSpendingAmount)
+                .build();
+    }
+
+    private void validateMemberExists(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new EntityNotFoundException("존재하지 않는 회원입니다. memberId=" + memberId);
+        }
+    }
+
+    private void validateTransactionOwnership(Long memberId, Account account) {
+        if (account == null) {
+            throw new EntityNotFoundException("카드에 연결된 계좌 정보가 없습니다.");
+        }
+
+        if (!account.getMemberId().equals(memberId)) {
+            throw new IllegalArgumentException(
+                    "해당 거래는 요청한 회원의 거래가 아닙니다. memberId=" + memberId
+            );
+        }
+    }
+
+    private BigDecimal calculateAvailableBalance(BigDecimal linkedAccountBalance, BigDecimal protectedBalance) {
+        BigDecimal availableBalance = linkedAccountBalance.subtract(protectedBalance);
+        return availableBalance.compareTo(BigDecimal.ZERO) < 0
+                ? BigDecimal.ZERO
+                : availableBalance;
+    }
+
+    private Integer calculateDaysUntilPaymentDue(LoanHistory nearestDueLoan) {
+        if (nearestDueLoan == null || nearestDueLoan.getExpectedRepaymentDate() == null) {
+            return null;
+        }
+
+        int days = (int) ChronoUnit.DAYS.between(
+                LocalDate.now(),
+                nearestDueLoan.getExpectedRepaymentDate()
+        );
+
+        return Math.max(days, 0);
+    }
+
+    private OffsetDateTime getStartOfMonth(OffsetDateTime baseDateTime) {
+        LocalDate date = baseDateTime.toLocalDate();
+        return date.withDayOfMonth(1)
+                .atStartOfDay()
+                .atOffset(ZoneOffset.of("+09:00"));
+    }
+
+    private OffsetDateTime getStartOfNextMonth(OffsetDateTime baseDateTime) {
+        LocalDate date = baseDateTime.toLocalDate();
+        return date.plusMonths(1)
+                .withDayOfMonth(1)
+                .atStartOfDay()
+                .atOffset(ZoneOffset.of("+09:00"));
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/CreditHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/CreditHistory.java
@@ -1,0 +1,37 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import com.nudgebank.bankbackend.auth.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "credit_history")
+public class CreditHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "credit_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "credit_score")
+    private Integer creditScore;
+
+    @Column(name = "credit_grade", length = 10)
+    private String creditGrade;
+
+    @Column(name = "evaluation_result", columnDefinition = "TEXT")
+    private String evaluationResult;
+
+    @Column(name = "evaluated_at")
+    private LocalDateTime evaluatedAt;
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/Loan.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/Loan.java
@@ -1,0 +1,45 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import com.nudgebank.bankbackend.auth.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "loan")
+public class Loan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "loan_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loan_application_id", nullable = false)
+    private LoanApplication loanApplication;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "principal_amount", precision = 15, scale = 2)
+    private BigDecimal principalAmount;
+
+    @Column(name = "interest_rate", precision = 5, scale = 2)
+    private BigDecimal interestRate;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "status", length = 200)
+    private String status;
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanApplication.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanApplication.java
@@ -1,0 +1,55 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import com.nudgebank.bankbackend.auth.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "loan_application")
+public class LoanApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "loan_application_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loan_product_id", nullable = false)
+    private LoanProduct loanProduct;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "credit_history_id", nullable = false)
+    private CreditHistory creditHistory;
+
+    @Column(name = "loan_amount", precision = 15, scale = 2)
+    private BigDecimal loanAmount;
+
+    @Column(name = "loan_term", length = 100)
+    private String loanTerm;
+
+    @Column(name = "application_status", length = 100)
+    private String applicationStatus;
+
+    @Column(name = "applied_at")
+    private LocalDateTime appliedAt;
+
+    @Column(name = "review_comment", length = 200)
+    private String reviewComment;
+
+    @Column(name = "monthly_income", precision = 15, scale = 2)
+    private BigDecimal monthlyIncome;
+
+    @Column(name = "salary_date")
+    private Integer salaryDate;
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
@@ -27,7 +27,7 @@ public class LoanHistory {
     private Member member;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "card_id", nullable = false, unique = true)
+    @JoinColumn(name = "card_id", nullable = false)
     private Card card;
 
     @Column(name = "total_principal", precision = 15, scale = 2)

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
@@ -1,0 +1,56 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.card.domain.Card;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "loan_history")
+public class LoanHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "loan_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false, unique = true)
+    private Card card;
+
+    @Column(name = "total_principal", precision = 15, scale = 2)
+    private BigDecimal totalPrincipal;
+
+    @Column(name = "repayment_account_number", length = 200)
+    private String repaymentAccountNumber;
+
+    @Column(name = "remaining_principal", precision = 15, scale = 2)
+    private BigDecimal remainingPrincipal;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "status", length = 100)
+    private String status;
+
+    @Column(name = "expected_repayment_date")
+    private LocalDate expectedRepaymentDate;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanProduct.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanProduct.java
@@ -1,0 +1,57 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "loan_product")
+public class LoanProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "loan_product_id")
+    private Long id;
+
+    @Column(name = "loan_product_name", length = 200)
+    private String loanProductName;
+
+    @Column(name = "loan_product_description", columnDefinition = "TEXT")
+    private String loanProductDescription;
+
+    @Column(name = "min_interest_rate", precision = 5, scale = 2)
+    private BigDecimal minInterestRate;
+
+    @Column(name = "max_interest_rate", precision = 5, scale = 2)
+    private BigDecimal maxInterestRate;
+
+    @Column(name = "max_limit_amount")
+    private Long maxLimitAmount;
+
+    @Column(name = "min_limit_amount")
+    private Long minLimitAmount;
+
+    @Column(name = "repayment_period_month")
+    private Integer repaymentPeriodMonth;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "loan_product_type", length = 50)
+    private String loanProductType;
+
+    @Column(name = "repayment_type", length = 50)
+    private String repaymentType;
+
+    @OneToMany(mappedBy = "loanProduct")
+    @Builder.Default
+    private List<LoanApplication> loanApplications = new ArrayList<>();
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/CreditHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/CreditHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.CreditHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreditHistoryRepository extends JpaRepository<CreditHistory, Long> {
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanApplicationRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanApplicationRepository.java
@@ -1,0 +1,11 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.LoanApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LoanApplicationRepository extends JpaRepository<LoanApplication, Long> {
+
+    Optional<LoanApplication> findTopByMember_MemberIdOrderByAppliedAtDesc(Long memberId);
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.LoanHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LoanHistoryRepository extends JpaRepository<LoanHistory, Long> {
+
+    Optional<LoanHistory> findByCard_CardIdAndStatus(Long cardId, String status);
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanProductRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanProductRepository.java
@@ -1,0 +1,7 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.LoanProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanProductRepository extends JpaRepository<LoanProduct, Long> {
+}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #14 

---

### 📝 작업 내용
- 사용자의 카드 거래 내역을 기준으로 계좌 잔액, 보호 잔액, 대출 상태, 월 소득, 급여일, 이번 달 누적 소비 금액을 조회하는 재무 상태 조회 API를 구현

---

### 📷 스크린샷 (선택)
- <img width="698" height="344" alt="image" src="https://github.com/user-attachments/assets/8f4deeff-cbe5-450b-b954-334253e85832" />
- 대출 관련 필드(monthlyRepaidAmount, monthlyRemainingRepaymentAmount)는
현재 로직이 구현되지 않아서 0으로 반환되며 추후 자동 상환 로직 구현 시 반영될 예정

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 카드 결제 처리 서비스 및 결제용 POST 엔드포인트 추가(결제 성공 시 거래 ID 반환)
  * 회원별 재무 상태 조회 API 추가(거래 기반 요약·잔액·대출·당월 소비 포함)
  * 여러 대출 도메인·엔티티 및 관련 저장소·DTO 추가
  * 결제 요청 DTO 및 보안 유틸리티(인증에서 사용자 ID 추출) 추가

* **변경**
  * 계좌 출금 시 금액·잔액 검증 로직 추가(과다인출 방지)
  * 일부 저장소 API 변경: 단건 조회 제거, 잠금 조회 및 월 합계 조회 기능 추가
  * 도메인/엔티티의 생성자/빌더 지원 확대

* **버그 수정**
  * 카드 엔드포인트에서 엔티티 미존재 시 404 응답 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->