### PR TITLE
Feat: 연령 기반 초기 baseline 조회 기능 구현

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**").permitAll()
             .requestMatchers("/api/cards/payment").authenticated()
             .requestMatchers("/api/finance-status/**").authenticated()
+            .requestMatchers("/api/baselines/**").authenticated()
             .anyRequest().permitAll()
         );
 

--- a/src/main/java/com/nudgebank/bankbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nudgebank/bankbackend/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.nudgebank.bankbackend.common.exception;
 import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
 import com.nudgebank.bankbackend.ocr.exception.InvalidCertificateUploadException;
 import com.nudgebank.bankbackend.ocr.exception.OcrClientException;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -35,6 +36,26 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CertificateVerificationException.class)
     public ResponseEntity<ErrorResponse> handleCertificateVerificationException(CertificateVerificationException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        HttpStatus.BAD_REQUEST.value(),
+                        exception.getMessage(),
+                        OffsetDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(
+                        HttpStatus.NOT_FOUND.value(),
+                        exception.getMessage(),
+                        OffsetDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(
                         HttpStatus.BAD_REQUEST.value(),

--- a/src/main/java/com/nudgebank/bankbackend/finance/controller/AgeGroupBaselineController.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/controller/AgeGroupBaselineController.java
@@ -1,0 +1,29 @@
+package com.nudgebank.bankbackend.finance.controller;
+
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
+import com.nudgebank.bankbackend.finance.dto.AgeGroupBaselineResponse;
+import com.nudgebank.bankbackend.finance.service.AgeGroupBaselineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/baselines")
+public class AgeGroupBaselineController {
+
+    private final AgeGroupBaselineService ageGroupBaselineService;
+
+    @GetMapping("/me")
+    public AgeGroupBaselineResponse getBaseline(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return ageGroupBaselineService.getBaseline(memberId);
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/domain/AgeGroupBaseline.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/domain/AgeGroupBaseline.java
@@ -1,0 +1,41 @@
+package com.nudgebank.bankbackend.finance.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "age_group_baseline")
+@Getter
+@NoArgsConstructor
+public class AgeGroupBaseline {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "age_baseline_id")
+    private Long id;
+
+    @Column(name = "age_group", nullable = false, length = 20)
+    private String ageGroup;
+
+    @Column(name = "avg_spending", precision = 15, scale = 2)
+    private BigDecimal avgSpending;
+
+    @Column(name = "essential_ratio", precision = 5, scale = 4)
+    private BigDecimal essentialRatio;
+
+    @Column(name = "risk_ratio", precision = 5, scale = 4)
+    private BigDecimal riskRatio;
+
+    @Column(name = "volatility", precision = 15, scale = 2)
+    private BigDecimal volatility;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/domain/AgeGroupBaseline.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/domain/AgeGroupBaseline.java
@@ -18,7 +18,7 @@ public class AgeGroupBaseline {
     @Column(name = "age_baseline_id")
     private Long id;
 
-    @Column(name = "age_group", nullable = false, length = 20)
+    @Column(name = "age_group", nullable = false, length = 20, unique = true)
     private String ageGroup;
 
     @Column(name = "avg_spending", precision = 15, scale = 2)

--- a/src/main/java/com/nudgebank/bankbackend/finance/dto/AgeGroupBaselineResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/dto/AgeGroupBaselineResponse.java
@@ -1,0 +1,18 @@
+package com.nudgebank.bankbackend.finance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class AgeGroupBaselineResponse {
+    private Long memberId;            // 회원 ID
+    private String ageGroup;          // 연령대 (예: 20s, 30s)
+    private Integer age;              // 나이
+    private BigDecimal avgSpending;   // 평균 소비 금액
+    private BigDecimal essentialRatio;// 필수 소비 비율
+    private BigDecimal riskRatio;     // 위험 소비 비율
+    private BigDecimal volatility;   // 소비 변동성
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/repository/AgeGroupBaselineRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/repository/AgeGroupBaselineRepository.java
@@ -1,0 +1,10 @@
+package com.nudgebank.bankbackend.finance.repository;
+
+import com.nudgebank.bankbackend.finance.domain.AgeGroupBaseline;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AgeGroupBaselineRepository extends JpaRepository<AgeGroupBaseline, Long> {
+    Optional<AgeGroupBaseline> findByAgeGroup(String ageGroup);
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/AgeGroupBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/AgeGroupBaselineService.java
@@ -1,0 +1,71 @@
+package com.nudgebank.bankbackend.finance.service;
+
+import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.auth.repository.MemberRepository;
+import com.nudgebank.bankbackend.finance.domain.AgeGroupBaseline;
+import com.nudgebank.bankbackend.finance.dto.AgeGroupBaselineResponse;
+import com.nudgebank.bankbackend.finance.repository.AgeGroupBaselineRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AgeGroupBaselineService {
+
+    private final MemberRepository memberRepository;
+    private final AgeGroupBaselineRepository ageGroupBaselineRepository;
+
+    public AgeGroupBaselineResponse getBaseline(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다. memberId=" + memberId));
+
+        if (member.getBirth() == null) {
+            throw new IllegalArgumentException("회원의 birth 정보가 없습니다. memberId=" + memberId);
+        }
+
+        int age = calculateAge(member.getBirth());
+        String ageGroup = toAgeGroup(age);
+
+        AgeGroupBaseline baseline = ageGroupBaselineRepository.findByAgeGroup(ageGroup)
+                .orElseThrow(() -> new EntityNotFoundException("연령대 baseline이 없습니다. ageGroup=" + ageGroup));
+
+        return AgeGroupBaselineResponse.builder()
+                .memberId(member.getMemberId())
+                .age(age)
+                .ageGroup(baseline.getAgeGroup())
+                .avgSpending(baseline.getAvgSpending())
+                .essentialRatio(baseline.getEssentialRatio())
+                .riskRatio(baseline.getRiskRatio())
+                .volatility(baseline.getVolatility())
+                .build();
+    }
+
+    private int calculateAge(LocalDate birth) {
+        return Period.between(birth, LocalDate.now()).getYears();
+    }
+
+    private String toAgeGroup(int age) {
+        if (age < 20) {
+            return "10s";
+        }
+        if (age < 30) {
+            return "20s";
+        }
+        if (age < 40) {
+            return "30s";
+        }
+        if (age < 50) {
+            return "40s";
+        }
+        if (age < 60) {
+            return "50s";
+        }
+        return "60s+";
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #37 

---

### 📝 작업 내용
- 연령대별 소비 기준 조회를 위한 AgeGroupBaseline 엔티티 및 레포지토리 추가
- 회원 생년월일을 기반으로 나이 및 연령대를 계산하는 로직 구현
- 연령대에 해당하는 baseline을 조회하는 서비스 로직 구현
- /api/baselines/me API 추가 및 응답 DTO 정의
- baseline 조회 시 예외 처리(EntityNotFoundException, IllegalArgumentException) 추가

---

### 📝 기능 흐름
로그인 사용자
→ member 조회
→ 나이 계산
→ 연령대 변환 (20s, 30s 등)
→ age_group_baseline 조회
→ 응답 반환

---

### 📷 스크린샷 (선택)
<img width="776" height="242" alt="image" src="https://github.com/user-attachments/assets/50373d19-a68c-46d6-8f65-df86d643dc8e" />

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자의 연령대별 기준 정보를 조회하는 새 API 엔드포인트 추가
  * 연령대별 지출 및 재무 지표 데이터를 반환

* **버그 수정**
  * 존재하지 않는 리소스 요청에 대해 404 응답 처리 추가
  * 잘못된 입력값에 대해 400 응답 처리 추가

* **보안**
  * 기준 정보 조회 엔드포인트에 인증 요구사항 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->