### PR TITLE
Feat: 자기계발 대출 신청 상태 및 OCR 제출 연계 구조 추가

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
@@ -40,6 +40,8 @@ public class SecurityConfig {
             .requestMatchers("/api/cards/payment").authenticated()
             .requestMatchers("/api/finance-status/**").authenticated()
             .requestMatchers("/api/baselines/**").authenticated()
+            .requestMatchers("/api/loan-applications/**").authenticated()
+            .requestMatchers("/api/certificates/**").authenticated()
             .anyRequest().permitAll()
         );
 

--- a/src/main/java/com/nudgebank/bankbackend/auth/controller/AuthController.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import com.nudgebank.bankbackend.auth.security.JwtProvider;
 import com.nudgebank.bankbackend.auth.security.SecurityUtil;
 import com.nudgebank.bankbackend.auth.service.AuthService;
 import io.jsonwebtoken.Claims;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Instant;
@@ -121,7 +122,7 @@ public class AuthController {
     }
 
     Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+        .orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
 
     return ResponseEntity.ok(new MeResponse(
         member.getMemberId(),

--- a/src/main/java/com/nudgebank/bankbackend/auth/controller/AuthController.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/controller/AuthController.java
@@ -2,11 +2,14 @@ package com.nudgebank.bankbackend.auth.controller;
 
 import com.nudgebank.bankbackend.auth.dto.AuthResponse;
 import com.nudgebank.bankbackend.auth.dto.LoginRequest;
+import com.nudgebank.bankbackend.auth.dto.MeResponse;
 import com.nudgebank.bankbackend.auth.dto.SignupRequest;
 import com.nudgebank.bankbackend.auth.domain.RefreshToken;
 import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.auth.repository.MemberRepository;
 import com.nudgebank.bankbackend.auth.security.CookieUtil;
 import com.nudgebank.bankbackend.auth.security.JwtProvider;
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
 import com.nudgebank.bankbackend.auth.service.AuthService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,6 +17,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.time.Instant;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,10 +32,12 @@ public class AuthController {
 
   private final AuthService authService;
   private final JwtProvider jwtProvider;
+  private final MemberRepository memberRepository;
 
-  public AuthController(AuthService authService, JwtProvider jwtProvider) {
+  public AuthController(AuthService authService, JwtProvider jwtProvider, MemberRepository memberRepository) {
     this.authService = authService;
     this.jwtProvider = jwtProvider;
+    this.memberRepository = memberRepository;
   }
 
   @PostMapping("/signup")
@@ -104,6 +111,23 @@ public class AuthController {
     }
     clearAuthCookies(res);
     return ResponseEntity.ok(new AuthResponse(true, "OK"));
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<MeResponse> me(Authentication authentication) {
+    Long memberId = SecurityUtil.extractUserId(authentication);
+    if (memberId == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+    return ResponseEntity.ok(new MeResponse(
+        member.getMemberId(),
+        member.getId(),
+        member.getName()
+    ));
   }
 
   private void setAuthCookies(HttpServletResponse res, AuthService.TokenPair tokens) {

--- a/src/main/java/com/nudgebank/bankbackend/auth/dto/MeResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/dto/MeResponse.java
@@ -1,0 +1,7 @@
+package com.nudgebank.bankbackend.auth.dto;
+
+public record MeResponse(
+    Long memberId,
+    String loginId,
+    String name
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/controller/CertificateSubmissionController.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/controller/CertificateSubmissionController.java
@@ -26,17 +26,15 @@ public class CertificateSubmissionController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     public CertificateSubmissionResponse submitCertificate(
-            @RequestParam(value = "memberId", required = false) Long memberId,
             @RequestParam("loanId") Long loanId,
             @RequestParam("certificateId") Long certificateId,
             @RequestParam("file") MultipartFile file,
             Authentication authentication
     ) {
-        Long authenticatedMemberId = SecurityUtil.extractUserId(authentication);
-        Long resolvedMemberId = authenticatedMemberId != null ? authenticatedMemberId : memberId;
-        if (resolvedMemberId == null) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        return certificateSubmissionService.submit(resolvedMemberId, loanId, certificateId, file);
+        return certificateSubmissionService.submit(memberId, loanId, certificateId, file);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/controller/CertificateSubmissionController.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/controller/CertificateSubmissionController.java
@@ -1,14 +1,18 @@
 package com.nudgebank.bankbackend.certificate.controller;
 
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
 import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
 import com.nudgebank.bankbackend.certificate.service.CertificateSubmissionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/certificates")
@@ -22,11 +26,17 @@ public class CertificateSubmissionController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     public CertificateSubmissionResponse submitCertificate(
-            @RequestParam("memberId") Long memberId,
+            @RequestParam(value = "memberId", required = false) Long memberId,
             @RequestParam("loanId") Long loanId,
             @RequestParam("certificateId") Long certificateId,
-            @RequestParam("file") MultipartFile file
+            @RequestParam("file") MultipartFile file,
+            Authentication authentication
     ) {
-        return certificateSubmissionService.submit(memberId, loanId, certificateId, file);
+        Long authenticatedMemberId = SecurityUtil.extractUserId(authentication);
+        Long resolvedMemberId = authenticatedMemberId != null ? authenticatedMemberId : memberId;
+        if (resolvedMemberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return certificateSubmissionService.submit(resolvedMemberId, loanId, certificateId, file);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateSubmissionRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateSubmissionRepository.java
@@ -4,6 +4,8 @@ import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CertificateSubmissionRepository extends JpaRepository<CertificateSubmission, Long> {
+    boolean existsByLoanApplicationId(Long loanApplicationId);
+
     boolean existsByMemberIdAndCertificateIdAndVerificationStatus(
             Long memberId,
             Long certificateId,

--- a/src/main/java/com/nudgebank/bankbackend/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/nudgebank/bankbackend/common/exception/ApiExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.nudgebank.bankbackend.common.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.time.OffsetDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest()
+            .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, exception.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse.of(HttpStatus.NOT_FOUND, exception.getMessage()));
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatus(ResponseStatusException exception) {
+        String message = exception.getReason() != null && !exception.getReason().isBlank()
+            ? exception.getReason()
+            : exception.getStatusCode().toString();
+
+        return ResponseEntity.status(exception.getStatusCode())
+            .body(ErrorResponse.of(exception.getStatusCode().value(), message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception exception) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "요청 처리 중 오류가 발생했습니다."
+            ));
+    }
+
+    public record ErrorResponse(
+        String timestamp,
+        int status,
+        String error,
+        String message
+    ) {
+        private static ErrorResponse of(HttpStatus status, String message) {
+            return new ErrorResponse(
+                OffsetDateTime.now().toString(),
+                status.value(),
+                status.getReasonPhrase(),
+                message
+            );
+        }
+
+        private static ErrorResponse of(int status, String message) {
+            HttpStatus resolved = HttpStatus.valueOf(status);
+            return of(resolved, message);
+        }
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/controller/LoanApplicationController.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/controller/LoanApplicationController.java
@@ -1,0 +1,45 @@
+package com.nudgebank.bankbackend.loan.controller;
+
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
+import com.nudgebank.bankbackend.loan.dto.LoanApplicationCreateRequest;
+import com.nudgebank.bankbackend.loan.dto.LoanApplicationSummaryResponse;
+import com.nudgebank.bankbackend.loan.service.LoanApplicationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/loan-applications")
+public class LoanApplicationController {
+
+    private final LoanApplicationService loanApplicationService;
+
+    @PostMapping
+    public LoanApplicationSummaryResponse create(
+        @RequestBody LoanApplicationCreateRequest request,
+        Authentication authentication
+    ) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return loanApplicationService.create(memberId, request);
+    }
+
+    @GetMapping("/me")
+    public List<LoanApplicationSummaryResponse> getMyApplications(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return loanApplicationService.getMyApplications(memberId);
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationCreateRequest.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationCreateRequest.java
@@ -1,0 +1,12 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+import java.math.BigDecimal;
+
+public record LoanApplicationCreateRequest(
+    String productKey,
+    BigDecimal loanAmount,
+    String loanTerm,
+    BigDecimal monthlyIncome,
+    Integer salaryDate,
+    String purpose
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationSummaryResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+import java.time.LocalDateTime;
+
+public record LoanApplicationSummaryResponse(
+    Long loanApplicationId,
+    String productKey,
+    String productName,
+    String applicationStatus,
+    LocalDateTime appliedAt,
+    boolean requiresCertificateSubmission,
+    boolean certificateSubmitted
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanApplicationRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanApplicationRepository.java
@@ -3,9 +3,12 @@ package com.nudgebank.bankbackend.loan.repository;
 import com.nudgebank.bankbackend.loan.domain.LoanApplication;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LoanApplicationRepository extends JpaRepository<LoanApplication, Long> {
 
     Optional<LoanApplication> findTopByMember_MemberIdOrderByAppliedAtDesc(Long memberId);
+
+    List<LoanApplication> findAllByMember_MemberIdOrderByAppliedAtDesc(Long memberId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanProductRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanProductRepository.java
@@ -3,5 +3,8 @@ package com.nudgebank.bankbackend.loan.repository;
 import com.nudgebank.bankbackend.loan.domain.LoanProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LoanProductRepository extends JpaRepository<LoanProduct, Long> {
+    Optional<LoanProduct> findByLoanProductType(String loanProductType);
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -1,0 +1,118 @@
+package com.nudgebank.bankbackend.loan.service;
+
+import com.nudgebank.bankbackend.account.repository.AccountRepository;
+import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.auth.repository.MemberRepository;
+import com.nudgebank.bankbackend.certificate.repository.CertificateSubmissionRepository;
+import com.nudgebank.bankbackend.credit.domain.CreditHistory;
+import com.nudgebank.bankbackend.credit.repository.CreditHistoryRepository;
+import com.nudgebank.bankbackend.loan.domain.LoanApplication;
+import com.nudgebank.bankbackend.loan.domain.LoanProduct;
+import com.nudgebank.bankbackend.loan.dto.LoanApplicationCreateRequest;
+import com.nudgebank.bankbackend.loan.dto.LoanApplicationSummaryResponse;
+import com.nudgebank.bankbackend.loan.repository.LoanApplicationRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanProductRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LoanApplicationService {
+
+    private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
+    private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
+    private static final String EMERGENCY_TYPE = "EMERGENCY";
+
+    private final LoanApplicationRepository loanApplicationRepository;
+    private final LoanProductRepository loanProductRepository;
+    private final CreditHistoryRepository creditHistoryRepository;
+    private final MemberRepository memberRepository;
+    private final CertificateSubmissionRepository certificateSubmissionRepository;
+    private final AccountRepository accountRepository;
+
+    public LoanApplicationSummaryResponse create(Long memberId, LoanApplicationCreateRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다. memberId=" + memberId));
+
+        CreditHistory creditHistory = creditHistoryRepository
+            .findTopByMemberIdOrderByEvaluatedAtDescCreditHistoryIdDesc(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("신용 이력이 없습니다. memberId=" + memberId));
+
+        String loanProductType = toLoanProductType(request.productKey());
+        LoanProduct loanProduct = loanProductRepository.findByLoanProductType(loanProductType)
+            .orElseThrow(() -> new EntityNotFoundException("대출 상품을 찾을 수 없습니다. type=" + loanProductType));
+
+        if (SELF_DEVELOPMENT_TYPE.equals(loanProductType)
+            && accountRepository.findAllByMemberId(memberId).isEmpty()) {
+            throw new IllegalArgumentException("자기계발 대출 신청을 위해 계좌가 필요합니다.");
+        }
+
+        String applicationStatus = SELF_DEVELOPMENT_TYPE.equals(loanProductType)
+            ? "DOCUMENT_REQUIRED"
+            : "UNDER_REVIEW";
+
+        LoanApplication savedApplication = loanApplicationRepository.save(
+            LoanApplication.builder()
+                .loanProduct(loanProduct)
+                .member(member)
+                .creditHistory(creditHistory)
+                .loanAmount(request.loanAmount())
+                .loanTerm(request.loanTerm())
+                .applicationStatus(applicationStatus)
+                .appliedAt(LocalDateTime.now())
+                .reviewComment(request.purpose())
+                .monthlyIncome(request.monthlyIncome())
+                .salaryDate(request.salaryDate())
+                .build()
+        );
+
+        return toSummary(savedApplication);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LoanApplicationSummaryResponse> getMyApplications(Long memberId) {
+        return loanApplicationRepository.findAllByMember_MemberIdOrderByAppliedAtDesc(memberId).stream()
+            .map(this::toSummary)
+            .toList();
+    }
+
+    private LoanApplicationSummaryResponse toSummary(LoanApplication loanApplication) {
+        boolean requiresCertificateSubmission =
+            SELF_DEVELOPMENT_TYPE.equals(loanApplication.getLoanProduct().getLoanProductType());
+        boolean certificateSubmitted = certificateSubmissionRepository
+            .existsByLoanApplicationId(loanApplication.getId());
+
+        return new LoanApplicationSummaryResponse(
+            loanApplication.getId(),
+            toProductKey(loanApplication.getLoanProduct().getLoanProductType()),
+            loanApplication.getLoanProduct().getLoanProductName(),
+            loanApplication.getApplicationStatus(),
+            loanApplication.getAppliedAt(),
+            requiresCertificateSubmission,
+            certificateSubmitted
+        );
+    }
+
+    private String toLoanProductType(String productKey) {
+        return switch (productKey) {
+            case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
+            case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
+            case "situate-loan" -> EMERGENCY_TYPE;
+            default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
+        };
+    }
+
+    private String toProductKey(String loanProductType) {
+        return switch (loanProductType) {
+            case SELF_DEVELOPMENT_TYPE -> "youth-loan";
+            case CONSUMPTION_ANALYSIS_TYPE -> "consumption-loan";
+            case EMERGENCY_TYPE -> "situate-loan";
+            default -> loanProductType;
+        };
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -59,9 +59,7 @@ public class LoanApplicationService {
 
         CreditHistory creditHistory = resolveCreditHistory(memberId, loanProductType);
 
-        String applicationStatus = SELF_DEVELOPMENT_TYPE.equals(loanProductType)
-            ? "DOCUMENT_REQUIRED"
-            : "UNDER_REVIEW";
+        String applicationStatus = "APPROVED";
 
         LoanApplication savedApplication = loanApplicationRepository.save(
             LoanApplication.builder()

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -39,18 +39,25 @@ public class LoanApplicationService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다. memberId=" + memberId));
 
-        CreditHistory creditHistory = creditHistoryRepository
-            .findTopByMemberIdOrderByEvaluatedAtDescCreditHistoryIdDesc(memberId)
-            .orElseThrow(() -> new EntityNotFoundException("신용 이력이 없습니다. memberId=" + memberId));
-
         String loanProductType = toLoanProductType(request.productKey());
         LoanProduct loanProduct = loanProductRepository.findByLoanProductType(loanProductType)
             .orElseThrow(() -> new EntityNotFoundException("대출 상품을 찾을 수 없습니다. type=" + loanProductType));
+
+        boolean alreadyApplied = loanApplicationRepository
+            .findAllByMember_MemberIdOrderByAppliedAtDesc(memberId)
+            .stream()
+            .anyMatch(application ->
+                loanProductType.equals(application.getLoanProduct().getLoanProductType()));
+        if (alreadyApplied) {
+            throw new IllegalArgumentException("이미 신청이 완료된 상품입니다. 내 대출 관리에서 진행 상태를 확인해 주세요.");
+        }
 
         if (SELF_DEVELOPMENT_TYPE.equals(loanProductType)
             && accountRepository.findAllByMemberId(memberId).isEmpty()) {
             throw new IllegalArgumentException("자기계발 대출 신청을 위해 계좌가 필요합니다.");
         }
+
+        CreditHistory creditHistory = resolveCreditHistory(memberId, loanProductType);
 
         String applicationStatus = SELF_DEVELOPMENT_TYPE.equals(loanProductType)
             ? "DOCUMENT_REQUIRED"
@@ -79,6 +86,25 @@ public class LoanApplicationService {
         return loanApplicationRepository.findAllByMember_MemberIdOrderByAppliedAtDesc(memberId).stream()
             .map(this::toSummary)
             .toList();
+    }
+
+    private CreditHistory resolveCreditHistory(Long memberId, String loanProductType) {
+        return creditHistoryRepository.findTopByMemberIdOrderByEvaluatedAtDescCreditHistoryIdDesc(memberId)
+            .orElseGet(() -> {
+                if (!SELF_DEVELOPMENT_TYPE.equals(loanProductType)) {
+                    throw new EntityNotFoundException("대출 심사를 위한 신용 정보가 없습니다.");
+                }
+
+                return creditHistoryRepository.save(
+                    CreditHistory.create(
+                        memberId,
+                        null,
+                        null,
+                        "SELF_DEVELOPMENT_APPLICATION_INITIALIZED",
+                        LocalDateTime.now()
+                    )
+                );
+            });
     }
 
     private LoanApplicationSummaryResponse toSummary(LoanApplication loanApplication) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #39 

---

### 📝 작업 내용
- 로그인 사용자 정보를 조회할 수 있도록 `GET /api/auth/me` API를 추가했습니다.
- 로그인 사용자가 대출을 신청할 수 있도록 `POST /api/loan-applications` API를 추가했습니다.
- 로그인 사용자의 대출 신청 목록과 상태를 조회할 수 있도록 `GET /api/loan-applications/me` API를 추가했습니다.
- 자기계발 대출 신청 건은 `DOCUMENT_REQUIRED` 상태로 저장하고, OCR 제출 필요 여부 및 제출 여부를 함께 응답하도록 구성했습니다.
- 자격증 OCR 제출이 `loan_application_id`와 연결되도록 정리했습니다.
- OCR 제출 시 `memberId`를 직접 받지 않고 로그인 사용자 기준으로 처리하도록 보완했습니다.
- 자기계발 대출은 계좌가 있는 회원만 신청 가능하도록 검증을 추가했습니다.
- 동일 상품 중복 신청을 방지하도록 로직을 추가했습니다.
- 자기계발 대출 신청 시 신용 이력이 없는 경우에도 초기 이력을 생성해 신청 흐름이 이어지도록 처리했습니다.

## 📌 확인 사항
- 계좌가 없는 회원은 자기계발 대출 신청이 차단되는 것을 확인했습니다.
- 계좌가 있는 회원은 자기계발 대출 신청 후 신청 상태 조회가 가능한 것을 확인했습니다.
- 자기계발 대출 신청 후 OCR 제출이 해당 신청 건과 연결되는 흐름을 확인했습니다.
---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 현재 사용자 프로필 조회 엔드포인트(/me) 추가
  * 대출 신청 생성 및 나의 신청 내역 조회 기능 추가
  * 인증 기반 인증서 제출 흐름으로 변경(클라이언트 제공 memberId 제거)
* **버그 수정 / 개선**
  * 인증 요구 범위 확대(대출·인증서 엔드포인트)
  * API 예외 처리를 통일해 JSON 형태의 오류 응답 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->