### PR TITLE
Feat: 개인 baseline 계산 및 연령/개인 가중치 기반 최종 baseline 조회 API 구현

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/card/repository/CardTransactionRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/repository/CardTransactionRepository.java
@@ -41,4 +41,30 @@ public interface CardTransactionRepository extends JpaRepository<CardTransaction
           @Param("transactionDatetime") OffsetDateTime transactionDatetime,
           @Param("transactionId") Long transactionId
   );
+
+    @EntityGraph(attributePaths = {"market", "category", "card"})
+    @Query("""
+    select ct
+    from CardTransaction ct
+    join ct.card c
+    join Account a on a.accountId = c.accountId
+    where a.memberId = :memberId
+      and ct.transactionDatetime >= :start
+      and ct.transactionDatetime < :end
+    order by ct.transactionDatetime asc
+""")
+    List<CardTransaction> findByMemberIdAndTransactionDatetimeBetween(
+            @Param("memberId") Long memberId,
+            @Param("start") OffsetDateTime start,
+            @Param("end") OffsetDateTime end
+    );
+
+    @Query("""
+    select min(ct.transactionDatetime)
+    from CardTransaction ct
+    join ct.card c
+    join Account a on a.accountId = c.accountId
+    where a.memberId = :memberId
+""")
+    OffsetDateTime findFirstTransactionDatetimeByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/finance/controller/PersonalBaselineController.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/controller/PersonalBaselineController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -18,12 +19,12 @@ public class PersonalBaselineController {
 
     private final PersonalBaselineService personalBaselineService;
 
-    @GetMapping("/final/me")
-    public FinalBaselineResponse getFinalBaseline(Authentication authentication) {
+    @GetMapping("/final/me/{transactionId}")
+    public FinalBaselineResponse getFinalBaseline(Authentication authentication, @PathVariable Long transactionId) {
         Long memberId = SecurityUtil.extractUserId(authentication);
         if (memberId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        return personalBaselineService.calculateAndGetFinalBaseline(memberId);
+        return personalBaselineService.calculateAndGetFinalBaseline(memberId, transactionId);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/finance/controller/PersonalBaselineController.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/controller/PersonalBaselineController.java
@@ -1,0 +1,29 @@
+package com.nudgebank.bankbackend.finance.controller;
+
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
+import com.nudgebank.bankbackend.finance.dto.FinalBaselineResponse;
+import com.nudgebank.bankbackend.finance.service.PersonalBaselineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/baselines")
+public class PersonalBaselineController {
+
+    private final PersonalBaselineService personalBaselineService;
+
+    @GetMapping("/final/me")
+    public FinalBaselineResponse getFinalBaseline(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return personalBaselineService.calculateAndGetFinalBaseline(memberId);
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/domain/ConsumerBaseline.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/domain/ConsumerBaseline.java
@@ -1,0 +1,109 @@
+package com.nudgebank.bankbackend.finance.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+    name = "consumer_baseline",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_consumer_baseline_member_month",
+        columnNames = {"member_id", "analysis_year_month"}
+    )
+)
+@Getter
+@NoArgsConstructor
+public class ConsumerBaseline {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "baseline_id")
+    private Long baselineId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "avg_spending", precision = 15, scale = 2)
+    private BigDecimal avgSpending;
+
+    @Column(name = "essential_ratio", precision = 5, scale = 4)
+    private BigDecimal essentialRatio;
+
+    @Column(name = "normal_ratio", precision = 5, scale = 4)
+    private BigDecimal normalRatio;
+
+    @Column(name = "discretionary_ratio", precision = 5, scale = 4)
+    private BigDecimal discretionaryRatio;
+
+    @Column(name = "risk_ratio", precision = 5, scale = 4)
+    private BigDecimal riskRatio;
+
+    @Column(name = "volatility", precision = 15, scale = 2)
+    private BigDecimal volatility;
+
+    @Column(name = "volatility_index", precision = 5, scale = 4)
+    private BigDecimal volatilityIndex;
+
+    @Column(name = "analysis_year_month", nullable = false)
+    private LocalDate analysisYearMonth;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
+    public static ConsumerBaseline create(
+            Long memberId,
+            BigDecimal avgSpending,
+            BigDecimal essentialRatio,
+            BigDecimal normalRatio,
+            BigDecimal discretionaryRatio,
+            BigDecimal riskRatio,
+            BigDecimal volatility,
+            BigDecimal volatilityIndex,
+            LocalDate analysisYearMonth,
+            OffsetDateTime now
+    ) {
+        ConsumerBaseline baseline = new ConsumerBaseline();
+        baseline.memberId = memberId;
+        baseline.avgSpending = avgSpending;
+        baseline.essentialRatio = essentialRatio;
+        baseline.normalRatio = normalRatio;
+        baseline.discretionaryRatio = discretionaryRatio;
+        baseline.riskRatio = riskRatio;
+        baseline.volatility = volatility;
+        baseline.volatilityIndex = volatilityIndex;
+        baseline.analysisYearMonth = analysisYearMonth;
+        baseline.createdAt = now;
+        baseline.updatedAt = now;
+        return baseline;
+    }
+
+    public void update(
+            BigDecimal avgSpending,
+            BigDecimal essentialRatio,
+            BigDecimal normalRatio,
+            BigDecimal discretionaryRatio,
+            BigDecimal riskRatio,
+            BigDecimal volatility,
+            BigDecimal volatilityIndex,
+            LocalDate analysisYearMonth,
+            OffsetDateTime now
+    ) {
+        this.avgSpending = avgSpending;
+        this.essentialRatio = essentialRatio;
+        this.normalRatio = normalRatio;
+        this.discretionaryRatio = discretionaryRatio;
+        this.riskRatio = riskRatio;
+        this.volatility = volatility;
+        this.volatilityIndex = volatilityIndex;
+        this.analysisYearMonth = analysisYearMonth;
+        this.updatedAt = now;
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/domain/ConsumptionType.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/domain/ConsumptionType.java
@@ -1,4 +1,4 @@
-package com.nudgebank.bankbackend.finance.service;
+package com.nudgebank.bankbackend.finance.domain;
 
 public enum ConsumptionType {
     ESSENTIAL,

--- a/src/main/java/com/nudgebank/bankbackend/finance/dto/FinalBaselineResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/dto/FinalBaselineResponse.java
@@ -1,0 +1,31 @@
+package com.nudgebank.bankbackend.finance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class FinalBaselineResponse {
+    private Long memberId;
+    private String ageGroup;
+    private Integer age;
+
+    private BigDecimal ageBaselineWeight;
+    private BigDecimal personalBaselineWeight;
+
+    private LocalDate baselineStartDate;
+    private LocalDate baselineEndDate;
+    private Integer usageDays;
+
+    private BigDecimal avgSpending;
+    private BigDecimal essentialRatio;
+    private BigDecimal normalRatio;
+    private BigDecimal discretionaryRatio;
+    private BigDecimal riskRatio;
+    private BigDecimal volatility;
+
+    private String baselineSource; // AGE_ONLY, MIXED, PERSONAL_HEAVY
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/dto/FinalBaselineResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/dto/FinalBaselineResponse.java
@@ -28,4 +28,6 @@ public class FinalBaselineResponse {
     private BigDecimal volatility;
 
     private String baselineSource; // AGE_ONLY, MIXED, PERSONAL_HEAVY
+
+    private FinancialStatusResponse financialStatusResponse;
 }

--- a/src/main/java/com/nudgebank/bankbackend/finance/repository/ConsumerBaselineRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/repository/ConsumerBaselineRepository.java
@@ -1,0 +1,11 @@
+package com.nudgebank.bankbackend.finance.repository;
+
+import com.nudgebank.bankbackend.finance.domain.ConsumerBaseline;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface ConsumerBaselineRepository extends JpaRepository<ConsumerBaseline, Long> {
+    Optional<ConsumerBaseline> findByMemberIdAndAnalysisYearMonth(Long memberId, LocalDate analysisYearMonth);
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/ConsumptionType.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/ConsumptionType.java
@@ -1,0 +1,8 @@
+package com.nudgebank.bankbackend.finance.service;
+
+public enum ConsumptionType {
+    ESSENTIAL,
+    NORMAL,
+    DISCRETIONARY,
+    RISK
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/ConsumptionTypeClassifier.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/ConsumptionTypeClassifier.java
@@ -1,0 +1,26 @@
+package com.nudgebank.bankbackend.finance.service;
+
+import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConsumptionTypeClassifier {
+
+    public ConsumptionType classify(CardTransaction transaction) {
+        String categoryName = transaction.getCategory() != null
+                ? safe(transaction.getCategory().getCategoryName())
+                : "";
+        return switch (categoryName) {
+            case "주점", "노래방" -> ConsumptionType.RISK;
+            case "택시", "대중교통", "편의점", "마트", "병원", "약국", "공과금", "통신비" -> ConsumptionType.ESSENTIAL;
+            case "영화관", "문화취미(pc방, 헬스장 등)", "백화점", "의류", "서점", "미용실", "카페" ->
+                    ConsumptionType.DISCRETIONARY;
+            case "음식점", "넛지뱅크" -> ConsumptionType.NORMAL;
+            default -> ConsumptionType.NORMAL;
+        };
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/ConsumptionTypeClassifier.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/ConsumptionTypeClassifier.java
@@ -1,6 +1,7 @@
 package com.nudgebank.bankbackend.finance.service;
 
 import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import com.nudgebank.bankbackend.finance.domain.ConsumptionType;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
@@ -67,8 +67,10 @@ public class PersonalBaselineService {
                 baselineEndDate.atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime()
         );
 
+        FinancialStatusResponse financialStatus = financialStatusService.getFinancialStatus(memberId, transactionId);
+
         if (transactions.isEmpty()) {
-            return buildAgeOnlyResponse(memberId, age, ageBaseline);
+            return buildAgeOnlyResponse(memberId, age, ageBaseline, financialStatus);
         }
 
         PersonalMetrics personal = calculatePersonalMetrics(baselineStartDate, today, transactions);
@@ -76,7 +78,7 @@ public class PersonalBaselineService {
 
         Weight weight = resolveWeight(firstTransactionDate, today);
 
-        FinancialStatusResponse financialStatus = financialStatusService.getFinancialStatus(memberId, transactionId);
+
 
         return FinalBaselineResponse.builder()
                 .memberId(memberId)
@@ -179,7 +181,7 @@ public class PersonalBaselineService {
                 );
     }
 
-    private FinalBaselineResponse buildAgeOnlyResponse(Long memberId, int age, AgeGroupBaseline baseline) {
+    private FinalBaselineResponse buildAgeOnlyResponse(Long memberId, int age, AgeGroupBaseline baseline, FinancialStatusResponse financialStatusResponse) {
         return FinalBaselineResponse.builder()
                 .memberId(memberId)
                 .ageGroup(baseline.getAgeGroup())
@@ -193,6 +195,7 @@ public class PersonalBaselineService {
                 .riskRatio(baseline.getRiskRatio())
                 .volatility(baseline.getVolatility())
                 .baselineSource("AGE_ONLY")
+                .financialStatusResponse(financialStatusResponse)
                 .build();
     }
 

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
@@ -50,9 +50,11 @@ public class PersonalBaselineService {
         AgeGroupBaseline ageBaseline = ageGroupBaselineRepository.findById(ageGroup)
                 .orElseThrow(() -> new EntityNotFoundException("연령 baseline이 없습니다. ageGroup=" + ageGroup));
 
+        FinancialStatusResponse financialStatus = financialStatusService.getFinancialStatus(memberId, transactionId);
+
         OffsetDateTime firstTransactionDatetime = cardTransactionRepository.findFirstTransactionDatetimeByMemberId(memberId);
         if (firstTransactionDatetime == null) {
-            return buildAgeOnlyResponse(memberId, age, ageBaseline);
+            return buildAgeOnlyResponse(memberId, age, ageBaseline,  financialStatus);
         }
 
         LocalDate today = LocalDate.now(ZoneId.systemDefault());
@@ -66,8 +68,6 @@ public class PersonalBaselineService {
                 baselineStartDate.atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime(),
                 baselineEndDate.atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime()
         );
-
-        FinancialStatusResponse financialStatus = financialStatusService.getFinancialStatus(memberId, transactionId);
 
         if (transactions.isEmpty()) {
             return buildAgeOnlyResponse(memberId, age, ageBaseline, financialStatus);

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
@@ -6,6 +6,7 @@ import com.nudgebank.bankbackend.card.domain.CardTransaction;
 import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
 import com.nudgebank.bankbackend.finance.domain.AgeGroupBaseline;
 import com.nudgebank.bankbackend.finance.domain.ConsumerBaseline;
+import com.nudgebank.bankbackend.finance.domain.ConsumptionType;
 import com.nudgebank.bankbackend.finance.dto.FinalBaselineResponse;
 import com.nudgebank.bankbackend.finance.dto.FinancialStatusResponse;
 import com.nudgebank.bankbackend.finance.repository.AgeGroupBaselineRepository;

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
@@ -1,0 +1,274 @@
+package com.nudgebank.bankbackend.finance.service;
+
+import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.auth.repository.MemberRepository;
+import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
+import com.nudgebank.bankbackend.finance.domain.AgeGroupBaseline;
+import com.nudgebank.bankbackend.finance.domain.ConsumerBaseline;
+import com.nudgebank.bankbackend.finance.dto.FinalBaselineResponse;
+import com.nudgebank.bankbackend.finance.repository.AgeGroupBaselineRepository;
+import com.nudgebank.bankbackend.finance.repository.ConsumerBaselineRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PersonalBaselineService {
+
+    private final MemberRepository memberRepository;
+    private final AgeGroupBaselineRepository ageGroupBaselineRepository;
+    private final ConsumerBaselineRepository consumerBaselineRepository;
+    private final CardTransactionRepository cardTransactionRepository;
+    private final ConsumptionTypeClassifier consumptionTypeClassifier;
+
+    public FinalBaselineResponse calculateAndGetFinalBaseline(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다. memberId=" + memberId));
+
+        int age = calculateAge(member);
+        String ageGroup = toAgeGroup(age);
+
+        AgeGroupBaseline ageBaseline = ageGroupBaselineRepository.findById(ageGroup)
+                .orElseThrow(() -> new EntityNotFoundException("연령 baseline이 없습니다. ageGroup=" + ageGroup));
+
+        OffsetDateTime firstTransactionDatetime = cardTransactionRepository.findFirstTransactionDatetimeByMemberId(memberId);
+        if (firstTransactionDatetime == null) {
+            return buildAgeOnlyResponse(memberId, age, ageBaseline);
+        }
+
+        LocalDate today = LocalDate.now(ZoneId.systemDefault());
+        LocalDate firstTransactionDate = firstTransactionDatetime.toLocalDate();
+        LocalDate ninetyDaysAgo = today.minusDays(90);
+        LocalDate baselineStartDate = firstTransactionDate.isAfter(ninetyDaysAgo) ? firstTransactionDate : ninetyDaysAgo;
+        LocalDate baselineEndDate = today.plusDays(1); // end exclusive
+
+        List<CardTransaction> transactions = cardTransactionRepository.findByMemberIdAndTransactionDatetimeBetween(
+                memberId,
+                baselineStartDate.atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime(),
+                baselineEndDate.atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime()
+        );
+
+        if (transactions.isEmpty()) {
+            return buildAgeOnlyResponse(memberId, age, ageBaseline);
+        }
+
+        PersonalMetrics personal = calculatePersonalMetrics(baselineStartDate, today, transactions);
+        saveOrUpdateConsumerBaseline(memberId, personal, today);
+
+        Weight weight = resolveWeight(firstTransactionDate, today);
+
+        return FinalBaselineResponse.builder()
+                .memberId(memberId)
+                .ageGroup(ageGroup)
+                .age(age)
+                .ageBaselineWeight(weight.ageWeight())
+                .personalBaselineWeight(weight.personalWeight())
+                .baselineStartDate(baselineStartDate)
+                .baselineEndDate(today)
+                .usageDays((int) ChronoUnit.DAYS.between(firstTransactionDate, today))
+                .avgSpending(weighted(ageBaseline.getAvgSpending(), personal.avgSpending(), weight))
+                .essentialRatio(weighted(ageBaseline.getEssentialRatio(), personal.essentialRatio(), weight))
+                .normalRatio(weighted(ageBaseline.getNormalRatio(), personal.normalRatio(), weight))
+                .discretionaryRatio(weighted(ageBaseline.getDiscretionaryRatio(), personal.discretionaryRatio(), weight))
+                .riskRatio(weighted(ageBaseline.getRiskRatio(), personal.riskRatio(), weight))
+                .volatility(weighted(ageBaseline.getVolatility(), personal.volatility(), weight))
+                .baselineSource(weight.personalWeight().compareTo(BigDecimal.ZERO) == 0 ? "AGE_ONLY"
+                        : weight.personalWeight().compareTo(new BigDecimal("0.7")) >= 0 ? "PERSONAL_HEAVY"
+                        : "MIXED")
+                .build();
+    }
+
+    private PersonalMetrics calculatePersonalMetrics(
+            LocalDate startDate,
+            LocalDate endDate,
+            List<CardTransaction> transactions
+    ) {
+        BigDecimal totalAmount = BigDecimal.ZERO;
+        Map<ConsumptionType, BigDecimal> amountByType = new EnumMap<>(ConsumptionType.class);
+        for (ConsumptionType type : ConsumptionType.values()) {
+            amountByType.put(type, BigDecimal.ZERO);
+        }
+
+        Map<LocalDate, BigDecimal> dailyTotals = new java.util.LinkedHashMap<>();
+        LocalDate cursor = startDate;
+        while (!cursor.isAfter(endDate)) {
+            dailyTotals.put(cursor, BigDecimal.ZERO);
+            cursor = cursor.plusDays(1);
+        }
+
+        for (CardTransaction transaction : transactions) {
+            BigDecimal amount = nullSafe(transaction.getAmount());
+            totalAmount = totalAmount.add(amount);
+
+            ConsumptionType type = consumptionTypeClassifier.classify(transaction);
+            amountByType.put(type, amountByType.get(type).add(amount));
+
+            LocalDate txDate = transaction.getTransactionDatetime().toLocalDate();
+            dailyTotals.put(txDate, dailyTotals.getOrDefault(txDate, BigDecimal.ZERO).add(amount));
+        }
+
+        int count = transactions.size();
+        BigDecimal avgSpending = count == 0
+                ? BigDecimal.ZERO
+                : totalAmount.divide(BigDecimal.valueOf(count), 2, RoundingMode.HALF_UP);
+
+        return new PersonalMetrics(
+                avgSpending,
+                ratio(amountByType.get(ConsumptionType.ESSENTIAL), totalAmount),
+                ratio(amountByType.get(ConsumptionType.NORMAL), totalAmount),
+                ratio(amountByType.get(ConsumptionType.DISCRETIONARY), totalAmount),
+                ratio(amountByType.get(ConsumptionType.RISK), totalAmount),
+                calculateStdDev(new ArrayList<>(dailyTotals.values()))
+        );
+    }
+
+    private void saveOrUpdateConsumerBaseline(Long memberId, PersonalMetrics personal, LocalDate today) {
+        OffsetDateTime now = OffsetDateTime.now();
+        LocalDate analysisYearMonth = today.withDayOfMonth(1);
+        BigDecimal volatilityIndex = calculateVolatilityIndex(personal.volatility());
+
+        consumerBaselineRepository.findByMemberIdAndAnalysisYearMonth(memberId, analysisYearMonth)
+                .ifPresentOrElse(
+                        baseline -> baseline.update(
+                                personal.avgSpending(),
+                                personal.essentialRatio(),
+                                personal.normalRatio(),
+                                personal.discretionaryRatio(),
+                                personal.riskRatio(),
+                                personal.volatility(),
+                                volatilityIndex,
+                                analysisYearMonth,
+                                now
+                        ),
+                        () -> consumerBaselineRepository.save(
+                                ConsumerBaseline.create(
+                                        memberId,
+                                        personal.avgSpending(),
+                                        personal.essentialRatio(),
+                                        personal.normalRatio(),
+                                        personal.discretionaryRatio(),
+                                        personal.riskRatio(),
+                                        personal.volatility(),
+                                        volatilityIndex,
+                                        analysisYearMonth,
+                                        now
+                                )
+                        )
+                );
+    }
+
+    private FinalBaselineResponse buildAgeOnlyResponse(Long memberId, int age, AgeGroupBaseline baseline) {
+        return FinalBaselineResponse.builder()
+                .memberId(memberId)
+                .ageGroup(baseline.getAgeGroup())
+                .age(age)
+                .ageBaselineWeight(BigDecimal.ONE)
+                .personalBaselineWeight(BigDecimal.ZERO)
+                .avgSpending(baseline.getAvgSpending())
+                .essentialRatio(baseline.getEssentialRatio())
+                .normalRatio(baseline.getNormalRatio())
+                .discretionaryRatio(baseline.getDiscretionaryRatio())
+                .riskRatio(baseline.getRiskRatio())
+                .volatility(baseline.getVolatility())
+                .baselineSource("AGE_ONLY")
+                .build();
+    }
+
+    private Weight resolveWeight(LocalDate firstTransactionDate, LocalDate today) {
+        long usageDays = Math.max(0, ChronoUnit.DAYS.between(firstTransactionDate, today));
+        if (usageDays < 30) {
+            return new Weight(new BigDecimal("0.9"), new BigDecimal("0.1"));
+        }
+        if (usageDays < 90) {
+            return new Weight(new BigDecimal("0.6"), new BigDecimal("0.4"));
+        }
+        if (usageDays < 180) {
+            return new Weight(new BigDecimal("0.3"), new BigDecimal("0.7"));
+        }
+        return new Weight(new BigDecimal("0.1"), new BigDecimal("0.9"));
+    }
+
+    private BigDecimal weighted(BigDecimal ageValue, BigDecimal personalValue, Weight weight) {
+        return nullSafe(ageValue).multiply(weight.ageWeight())
+                .add(nullSafe(personalValue).multiply(weight.personalWeight()))
+                .setScale(4, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal ratio(BigDecimal part, BigDecimal total) {
+        if (total == null || total.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return nullSafe(part).divide(total, 4, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculateStdDev(List<BigDecimal> values) {
+        if (values.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+        double[] arr = values.stream().mapToDouble(BigDecimal::doubleValue).toArray();
+        double mean = java.util.Arrays.stream(arr).average().orElse(0.0);
+        double variance = java.util.Arrays.stream(arr)
+                .map(v -> Math.pow(v - mean, 2))
+                .average()
+                .orElse(0.0);
+        return BigDecimal.valueOf(Math.sqrt(variance)).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculateVolatilityIndex(BigDecimal volatility) {
+        if (volatility == null || volatility.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
+        }
+
+        // TODO: 연령대 평균 대비 지수 계산 기준이 확정되면 교체
+        return BigDecimal.ONE.setScale(4, RoundingMode.HALF_UP);
+    }
+
+    private int calculateAge(Member member) {
+        if (member.getBirth() == null) {
+            throw new IllegalArgumentException("회원의 birth 정보가 없습니다. memberId=" + member.getMemberId());
+        }
+        return Period.between(member.getBirth(), LocalDate.now()).getYears();
+    }
+
+    private String toAgeGroup(int age) {
+        if (age < 20) return "10s";
+        if (age < 30) return "20s";
+        if (age < 40) return "30s";
+        if (age < 50) return "40s";
+        if (age < 60) return "50s";
+        return "60s+";
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    private record PersonalMetrics(
+            BigDecimal avgSpending,
+            BigDecimal essentialRatio,
+            BigDecimal normalRatio,
+            BigDecimal discretionaryRatio,
+            BigDecimal riskRatio,
+            BigDecimal volatility
+    ) {
+    }
+
+    private record Weight(BigDecimal ageWeight, BigDecimal personalWeight) {
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
@@ -7,6 +7,7 @@ import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
 import com.nudgebank.bankbackend.finance.domain.AgeGroupBaseline;
 import com.nudgebank.bankbackend.finance.domain.ConsumerBaseline;
 import com.nudgebank.bankbackend.finance.dto.FinalBaselineResponse;
+import com.nudgebank.bankbackend.finance.dto.FinancialStatusResponse;
 import com.nudgebank.bankbackend.finance.repository.AgeGroupBaselineRepository;
 import com.nudgebank.bankbackend.finance.repository.ConsumerBaselineRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -36,8 +37,9 @@ public class PersonalBaselineService {
     private final ConsumerBaselineRepository consumerBaselineRepository;
     private final CardTransactionRepository cardTransactionRepository;
     private final ConsumptionTypeClassifier consumptionTypeClassifier;
+    private final FinancialStatusService financialStatusService;
 
-    public FinalBaselineResponse calculateAndGetFinalBaseline(Long memberId) {
+    public FinalBaselineResponse calculateAndGetFinalBaseline(Long memberId, Long transactionId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다. memberId=" + memberId));
 
@@ -73,6 +75,8 @@ public class PersonalBaselineService {
 
         Weight weight = resolveWeight(firstTransactionDate, today);
 
+        FinancialStatusResponse financialStatus = financialStatusService.getFinancialStatus(memberId, transactionId);
+
         return FinalBaselineResponse.builder()
                 .memberId(memberId)
                 .ageGroup(ageGroup)
@@ -91,6 +95,7 @@ public class PersonalBaselineService {
                 .baselineSource(weight.personalWeight().compareTo(BigDecimal.ZERO) == 0 ? "AGE_ONLY"
                         : weight.personalWeight().compareTo(new BigDecimal("0.7")) >= 0 ? "PERSONAL_HEAVY"
                         : "MIXED")
+                .financialStatusResponse(financialStatus)
                 .build();
     }
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #41 
---

### 📝 작업 내용
- 개인 baseline 계산 및 최종 baseline API 구현

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 개인화된 재무 기준선 조회 API 추가 (GET /api/baselines/final/me/{transactionId}) — 거래 분석 기반 평균 지출, 소비유형별 비율(필수/정상/재량/위험), 변동성, 사용일수, 기간 및 출처 반환
  * 연령 기준선과 개인 기준선의 가중치 블렌딩 제공

* **데이터**
  * 개인 거래 조회 및 최초 거래일 기반의 기간 설정 및 월별 기준선 저장 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->