### PR TITLE
Feat: 내 대출 관리 조회 API 구현

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
             .requestMatchers("/api/finance-status/**").authenticated()
             .requestMatchers("/api/baselines/**").authenticated()
             .requestMatchers("/api/loan-applications/**").authenticated()
+            .requestMatchers("/api/loans/me/**").authenticated()
             .requestMatchers("/api/certificates/**").authenticated()
             .anyRequest().permitAll()
         );

--- a/src/main/java/com/nudgebank/bankbackend/loan/controller/MyLoanManagementController.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/controller/MyLoanManagementController.java
@@ -1,0 +1,50 @@
+package com.nudgebank.bankbackend.loan.controller;
+
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
+import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentHistoryResponse;
+import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentScheduleResponse;
+import com.nudgebank.bankbackend.loan.dto.MyLoanSummaryResponse;
+import com.nudgebank.bankbackend.loan.service.MyLoanManagementService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/loans/me")
+public class MyLoanManagementController {
+
+    private final MyLoanManagementService myLoanManagementService;
+
+    @GetMapping("/summary")
+    public MyLoanSummaryResponse getSummary(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getSummary(memberId);
+    }
+
+    @GetMapping("/repayment-schedules")
+    public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getRepaymentSchedules(memberId);
+    }
+
+    @GetMapping("/repayment-histories")
+    public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getRepaymentHistories(memberId);
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
@@ -1,0 +1,55 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "loan_repayment_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Access(AccessType.FIELD)
+public class LoanRepaymentHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "repayment_id")
+    private Long repaymentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loan_history_id", nullable = false)
+    private LoanHistory loanHistory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transaction_id", nullable = false)
+    private CardTransaction transaction;
+
+    @Column(name = "repayment_amount", precision = 15, scale = 2)
+    private BigDecimal repaymentAmount;
+
+    @Column(name = "repayment_rate", precision = 5, scale = 2)
+    private BigDecimal repaymentRate;
+
+    @Column(name = "repayment_datetime")
+    private OffsetDateTime repaymentDatetime;
+
+    @Column(name = "remaining_balance", precision = 15, scale = 2)
+    private BigDecimal remainingBalance;
+
+    @Column(name = "\"Key\"")
+    private String recordKey;
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/RepaymentSchedule.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/RepaymentSchedule.java
@@ -1,0 +1,59 @@
+package com.nudgebank.bankbackend.loan.domain;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "repayment_schedule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Access(AccessType.FIELD)
+public class RepaymentSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    private Long scheduleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loan_history_id", nullable = false)
+    private LoanHistory loanHistory;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(name = "planned_principal", precision = 15, scale = 2)
+    private BigDecimal plannedPrincipal;
+
+    @Column(name = "planned_interest", precision = 15, scale = 2)
+    private BigDecimal plannedInterest;
+
+    @Column(name = "paid_principal", precision = 15, scale = 2)
+    private BigDecimal paidPrincipal;
+
+    @Column(name = "paid_interest", precision = 15, scale = 2)
+    private BigDecimal paidInterest;
+
+    @Column(name = "is_settled")
+    private Boolean isSettled;
+
+    @Column(name = "overdue_days")
+    private Integer overdueDays;
+
+    @Column(name = "\"Key\"")
+    private String recordKey;
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/MyLoanRepaymentHistoryResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/MyLoanRepaymentHistoryResponse.java
@@ -1,0 +1,12 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record MyLoanRepaymentHistoryResponse(
+    Long repaymentId,
+    BigDecimal repaymentAmount,
+    BigDecimal repaymentRate,
+    OffsetDateTime repaymentDatetime,
+    BigDecimal remainingBalance
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/MyLoanRepaymentScheduleResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/MyLoanRepaymentScheduleResponse.java
@@ -1,0 +1,15 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record MyLoanRepaymentScheduleResponse(
+    Long scheduleId,
+    LocalDate dueDate,
+    BigDecimal plannedPrincipal,
+    BigDecimal plannedInterest,
+    BigDecimal paidPrincipal,
+    BigDecimal paidInterest,
+    boolean settled,
+    Integer overdueDays
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/MyLoanSummaryResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/MyLoanSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record MyLoanSummaryResponse(
+    Long loanHistoryId,
+    String status,
+    BigDecimal totalPrincipal,
+    BigDecimal remainingPrincipal,
+    BigDecimal repaidPrincipal,
+    BigDecimal interestRate,
+    LocalDate startDate,
+    LocalDate endDate,
+    LocalDate nextPaymentDate,
+    BigDecimal nextPaymentAmount,
+    BigDecimal cumulativeInterest,
+    String repaymentAccountNumber
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface LoanHistoryRepository extends JpaRepository<LoanHistory, Long> {
 
     Optional<LoanHistory> findByCard_CardIdAndStatus(Long cardId, String status);
+
+    Optional<LoanHistory> findTopByMember_MemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepaymentHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepaymentHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.LoanRepaymentHistory;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanRepaymentHistoryRepository extends JpaRepository<LoanRepaymentHistory, Long> {
+
+    List<LoanRepaymentHistory> findTop10ByLoanHistory_IdOrderByRepaymentDatetimeDesc(Long loanHistoryId);
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
@@ -1,0 +1,10 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.Loan;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanRepository extends JpaRepository<Loan, Long> {
+
+    Optional<Loan> findTopByMember_MemberIdOrderByStartDateDescIdDesc(Long memberId);
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/RepaymentScheduleRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/RepaymentScheduleRepository.java
@@ -1,0 +1,10 @@
+package com.nudgebank.bankbackend.loan.repository;
+
+import com.nudgebank.bankbackend.loan.domain.RepaymentSchedule;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepaymentScheduleRepository extends JpaRepository<RepaymentSchedule, Long> {
+
+    List<RepaymentSchedule> findAllByLoanHistory_IdOrderByDueDateAsc(Long loanHistoryId);
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -1,0 +1,105 @@
+package com.nudgebank.bankbackend.loan.service;
+
+import com.nudgebank.bankbackend.loan.domain.LoanHistory;
+import com.nudgebank.bankbackend.loan.domain.Loan;
+import com.nudgebank.bankbackend.loan.domain.RepaymentSchedule;
+import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentHistoryResponse;
+import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentScheduleResponse;
+import com.nudgebank.bankbackend.loan.dto.MyLoanSummaryResponse;
+import com.nudgebank.bankbackend.loan.repository.LoanHistoryRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanRepaymentHistoryRepository;
+import com.nudgebank.bankbackend.loan.repository.RepaymentScheduleRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyLoanManagementService {
+
+    private final LoanHistoryRepository loanHistoryRepository;
+    private final LoanRepository loanRepository;
+    private final RepaymentScheduleRepository repaymentScheduleRepository;
+    private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
+
+    public MyLoanSummaryResponse getSummary(Long memberId) {
+        LoanHistory loanHistory = getLatestLoanHistory(memberId);
+        Loan loan = loanRepository.findTopByMember_MemberIdOrderByStartDateDescIdDesc(memberId).orElse(null);
+        List<RepaymentSchedule> schedules =
+            repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId());
+
+        RepaymentSchedule nextSchedule = schedules.stream()
+            .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsSettled()))
+            .findFirst()
+            .orElse(null);
+
+        BigDecimal totalPrincipal = nullSafe(loanHistory.getTotalPrincipal());
+        BigDecimal remainingPrincipal = nullSafe(loanHistory.getRemainingPrincipal());
+        BigDecimal repaidPrincipal = totalPrincipal.subtract(remainingPrincipal);
+        BigDecimal cumulativeInterest = schedules.stream()
+            .map(RepaymentSchedule::getPaidInterest)
+            .map(this::nullSafe)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return new MyLoanSummaryResponse(
+            loanHistory.getId(),
+            loanHistory.getStatus(),
+            totalPrincipal,
+            remainingPrincipal,
+            repaidPrincipal.max(BigDecimal.ZERO),
+            loan != null ? nullSafe(loan.getInterestRate()) : BigDecimal.ZERO,
+            loanHistory.getStartDate(),
+            loanHistory.getEndDate(),
+            nextSchedule != null ? nextSchedule.getDueDate() : loanHistory.getExpectedRepaymentDate(),
+            nextSchedule != null
+                ? nullSafe(nextSchedule.getPlannedPrincipal()).add(nullSafe(nextSchedule.getPlannedInterest()))
+                : BigDecimal.ZERO,
+            cumulativeInterest,
+            loanHistory.getRepaymentAccountNumber()
+        );
+    }
+
+    public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(Long memberId) {
+        LoanHistory loanHistory = getLatestLoanHistory(memberId);
+        return repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId()).stream()
+            .map(schedule -> new MyLoanRepaymentScheduleResponse(
+                schedule.getScheduleId(),
+                schedule.getDueDate(),
+                nullSafe(schedule.getPlannedPrincipal()),
+                nullSafe(schedule.getPlannedInterest()),
+                nullSafe(schedule.getPaidPrincipal()),
+                nullSafe(schedule.getPaidInterest()),
+                Boolean.TRUE.equals(schedule.getIsSettled()),
+                schedule.getOverdueDays()
+            ))
+            .toList();
+    }
+
+    public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(Long memberId) {
+        LoanHistory loanHistory = getLatestLoanHistory(memberId);
+        return loanRepaymentHistoryRepository
+            .findTop10ByLoanHistory_IdOrderByRepaymentDatetimeDesc(loanHistory.getId()).stream()
+            .map(history -> new MyLoanRepaymentHistoryResponse(
+                history.getRepaymentId(),
+                nullSafe(history.getRepaymentAmount()),
+                nullSafe(history.getRepaymentRate()),
+                history.getRepaymentDatetime(),
+                nullSafe(history.getRemainingBalance())
+            ))
+            .toList();
+    }
+
+    private LoanHistory getLatestLoanHistory(Long memberId) {
+        return loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("대출 관리 정보가 없습니다."));
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #52 

---

### 📝 작업 내용
- 로그인 사용자 기준 내 대출 관리 조회 API 추가
- 대출 요약, 상환 일정, 최근 상환 내역 조회용 DTO/Service/Repository 구현
- `loan_history`, `repayment_schedule`, `loan_repayment_history`, `loan` 기준으로 관리 화면 응답 구성

---

### 📷 스크린샷 (선택)
- <img width="548" height="754" alt="image" src="https://github.com/user-attachments/assets/5f986062-442b-4298-81e3-f18cd88aea2e" />
- 
<img width="643" height="801" alt="image" src="https://github.com/user-attachments/assets/13967fd3-7263-400f-ba08-b1e339daa39b" />

<img width="634" height="813" alt="image" src="https://github.com/user-attachments/assets/358f8ce9-8212-42a2-ad2b-a658aa414fc5" />


---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 인증된 사용자 전용 대출 요약 조회 기능 추가 — 대출액, 잔여·상환액, 이자율, 시작/종료일, 다음 납부일 및 납부액, 누적 이자, 상환 계좌 정보 확인 가능
* 상환 일정 조회 기능 추가 — 예정·실제 원리금, 정산 여부, 연체일 등 정렬된 일정 조회 가능
* 상환 이력 조회 기능 추가 — 최신 최대 10건의 상환 거래 내역 및 금액, 이율, 일시, 잔액 정보 확인 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->