### PR TITLE
Feat: 우대금리 자격증 OCR 인증 로직 분리

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/controller/CertificateSubmissionController.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/controller/CertificateSubmissionController.java
@@ -26,7 +26,8 @@ public class CertificateSubmissionController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     public CertificateSubmissionResponse submitCertificate(
-            @RequestParam("loanId") Long loanId,
+            @RequestParam(value = "loanApplicationId", required = false) Long loanApplicationId,
+            @RequestParam(value = "loanId", required = false) Long legacyLoanId,
             @RequestParam("certificateId") Long certificateId,
             @RequestParam("file") MultipartFile file,
             Authentication authentication
@@ -35,6 +36,7 @@ public class CertificateSubmissionController {
         if (memberId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        return certificateSubmissionService.submit(memberId, loanId, certificateId, file);
+        Long resolvedLoanApplicationId = loanApplicationId != null ? loanApplicationId : legacyLoanId;
+        return certificateSubmissionService.submit(memberId, resolvedLoanApplicationId, certificateId, file);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateSubmissionRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/repository/CertificateSubmissionRepository.java
@@ -3,6 +3,8 @@ package com.nudgebank.bankbackend.certificate.repository;
 import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CertificateSubmissionRepository extends JpaRepository<CertificateSubmission, Long> {
     boolean existsByLoanApplicationId(Long loanApplicationId);
 
@@ -11,4 +13,6 @@ public interface CertificateSubmissionRepository extends JpaRepository<Certifica
             Long certificateId,
             String verificationStatus
     );
+
+    Optional<CertificateSubmission> findTopByLoanApplicationIdOrderBySubmittedAtDescSubmissionIdDesc(Long loanApplicationId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
@@ -38,11 +38,12 @@ public class CertificateSubmissionService {
     @Transactional
     public CertificateSubmissionResponse submit(
             Long memberId,
-            Long loanId,
+            Long loanApplicationId,
             Long certificateId,
             MultipartFile file
     ) {
-        validateRequest(memberId, loanId, certificateId, file);
+        validateRequest(memberId, loanApplicationId, certificateId, file);
+        validateDuplicateVerifiedCertificate(memberId, certificateId);
 
         OcrExtractResponse ocrResponse = ocrClient.extract(file);
         OffsetDateTime submittedAt = OffsetDateTime.now();
@@ -56,7 +57,7 @@ public class CertificateSubmissionService {
 
         CertificateSubmission submission = CertificateSubmission.builder()
                 .memberId(memberId)
-                .loanApplicationId(loanId)
+                .loanApplicationId(loanApplicationId)
                 .certificateId(certificateId)
                 .fileUrl(file.getOriginalFilename())
                 .ocrText(ocrResponse.extractedText())
@@ -82,16 +83,29 @@ public class CertificateSubmissionService {
 
     private void validateRequest(
             Long memberId,
-            Long loanId,
+            Long loanApplicationId,
             Long certificateId,
             MultipartFile file
     ) {
-        if (memberId == null || loanId == null || certificateId == null) {
-            throw new InvalidCertificateUploadException("memberId, loanId, certificateId are required");
+        if (memberId == null || loanApplicationId == null || certificateId == null) {
+            throw new InvalidCertificateUploadException("memberId, loanApplicationId, certificateId are required");
         }
 
         if (file == null || file.isEmpty()) {
             throw new InvalidCertificateUploadException("Certificate file is required");
+        }
+    }
+
+    private void validateDuplicateVerifiedCertificate(Long memberId, Long certificateId) {
+        boolean alreadyVerified = certificateSubmissionRepository
+                .existsByMemberIdAndCertificateIdAndVerificationStatus(
+                        memberId,
+                        certificateId,
+                        "VERIFIED"
+                );
+
+        if (alreadyVerified) {
+            throw new IllegalArgumentException("이미 인증 완료된 자격증입니다.");
         }
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationSummaryResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationSummaryResponse.java
@@ -9,5 +9,8 @@ public record LoanApplicationSummaryResponse(
     String applicationStatus,
     LocalDateTime appliedAt,
     boolean requiresCertificateSubmission,
-    boolean certificateSubmitted
+    boolean certificateSubmitted,
+    boolean preferentialRateVerificationAvailable,
+    boolean preferentialRateVerificationSubmitted,
+    String preferentialRateVerificationStatus
 ) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -106,10 +106,14 @@ public class LoanApplicationService {
     }
 
     private LoanApplicationSummaryResponse toSummary(LoanApplication loanApplication) {
-        boolean requiresCertificateSubmission =
+        boolean preferentialRateVerificationAvailable =
             SELF_DEVELOPMENT_TYPE.equals(loanApplication.getLoanProduct().getLoanProductType());
-        boolean certificateSubmitted = certificateSubmissionRepository
-            .existsByLoanApplicationId(loanApplication.getId());
+        var latestSubmission = certificateSubmissionRepository
+            .findTopByLoanApplicationIdOrderBySubmittedAtDescSubmissionIdDesc(loanApplication.getId());
+        boolean certificateSubmitted = latestSubmission.isPresent();
+        String preferentialRateVerificationStatus = latestSubmission
+            .map(submission -> submission.getVerificationStatus())
+            .orElse(null);
 
         return new LoanApplicationSummaryResponse(
             loanApplication.getId(),
@@ -117,8 +121,11 @@ public class LoanApplicationService {
             loanApplication.getLoanProduct().getLoanProductName(),
             loanApplication.getApplicationStatus(),
             loanApplication.getAppliedAt(),
-            requiresCertificateSubmission,
-            certificateSubmitted
+            preferentialRateVerificationAvailable,
+            certificateSubmitted,
+            preferentialRateVerificationAvailable,
+            certificateSubmitted,
+            preferentialRateVerificationStatus
         );
     }
 

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -108,6 +108,7 @@ public class LoanApplicationService {
     private LoanApplicationSummaryResponse toSummary(LoanApplication loanApplication) {
         boolean preferentialRateVerificationAvailable =
             SELF_DEVELOPMENT_TYPE.equals(loanApplication.getLoanProduct().getLoanProductType());
+        boolean requiresCertificateSubmission = false;
         var latestSubmission = certificateSubmissionRepository
             .findTopByLoanApplicationIdOrderBySubmittedAtDescSubmissionIdDesc(loanApplication.getId());
         boolean certificateSubmitted = latestSubmission.isPresent();
@@ -121,7 +122,7 @@ public class LoanApplicationService {
             loanApplication.getLoanProduct().getLoanProductName(),
             loanApplication.getApplicationStatus(),
             loanApplication.getAppliedAt(),
-            preferentialRateVerificationAvailable,
+            requiresCertificateSubmission,
             certificateSubmitted,
             preferentialRateVerificationAvailable,
             certificateSubmitted,

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -2,16 +2,20 @@ package com.nudgebank.bankbackend.loan.service;
 
 import com.nudgebank.bankbackend.loan.domain.LoanHistory;
 import com.nudgebank.bankbackend.loan.domain.Loan;
+import com.nudgebank.bankbackend.loan.domain.LoanApplication;
 import com.nudgebank.bankbackend.loan.domain.RepaymentSchedule;
 import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentHistoryResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentScheduleResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanSummaryResponse;
+import com.nudgebank.bankbackend.loan.repository.LoanApplicationRepository;
 import com.nudgebank.bankbackend.loan.repository.LoanHistoryRepository;
 import com.nudgebank.bankbackend.loan.repository.LoanRepository;
 import com.nudgebank.bankbackend.loan.repository.LoanRepaymentHistoryRepository;
 import com.nudgebank.bankbackend.loan.repository.RepaymentScheduleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,13 +26,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MyLoanManagementService {
 
+    private final LoanApplicationRepository loanApplicationRepository;
     private final LoanHistoryRepository loanHistoryRepository;
     private final LoanRepository loanRepository;
     private final RepaymentScheduleRepository repaymentScheduleRepository;
     private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
 
     public MyLoanSummaryResponse getSummary(Long memberId) {
-        LoanHistory loanHistory = getLatestLoanHistory(memberId);
+        LoanHistory loanHistory = loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId).orElse(null);
+        if (loanHistory == null) {
+            return buildPendingLoanSummary(memberId);
+        }
+
         Loan loan = loanRepository.findTopByMember_MemberIdOrderByStartDateDescIdDesc(memberId).orElse(null);
         List<RepaymentSchedule> schedules =
             repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId());
@@ -65,7 +74,12 @@ public class MyLoanManagementService {
     }
 
     public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(Long memberId) {
-        LoanHistory loanHistory = getLatestLoanHistory(memberId);
+        LoanHistory loanHistory = loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId).orElse(null);
+        if (loanHistory == null) {
+            ensureDisplayableLoanExists(memberId);
+            return List.of();
+        }
+
         return repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId()).stream()
             .map(schedule -> new MyLoanRepaymentScheduleResponse(
                 schedule.getScheduleId(),
@@ -81,7 +95,12 @@ public class MyLoanManagementService {
     }
 
     public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(Long memberId) {
-        LoanHistory loanHistory = getLatestLoanHistory(memberId);
+        LoanHistory loanHistory = loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId).orElse(null);
+        if (loanHistory == null) {
+            ensureDisplayableLoanExists(memberId);
+            return List.of();
+        }
+
         return loanRepaymentHistoryRepository
             .findTop10ByLoanHistory_IdOrderByRepaymentDatetimeDesc(loanHistory.getId()).stream()
             .map(history -> new MyLoanRepaymentHistoryResponse(
@@ -92,6 +111,44 @@ public class MyLoanManagementService {
                 nullSafe(history.getRemainingBalance())
             ))
             .toList();
+    }
+
+    private MyLoanSummaryResponse buildPendingLoanSummary(Long memberId) {
+        LoanApplication application = ensureDisplayableLoanExists(memberId);
+        BigDecimal totalPrincipal = nullSafe(application.getLoanAmount());
+        BigDecimal interestRate = application.getLoanProduct().getMinInterestRate() != null
+            ? application.getLoanProduct().getMinInterestRate()
+            : BigDecimal.ZERO;
+        int repaymentMonths = application.getLoanProduct().getRepaymentPeriodMonth() != null
+            && application.getLoanProduct().getRepaymentPeriodMonth() > 0
+            ? application.getLoanProduct().getRepaymentPeriodMonth()
+            : 1;
+        LocalDate startDate = application.getAppliedAt() != null
+            ? application.getAppliedAt().toLocalDate()
+            : LocalDate.now();
+        BigDecimal nextPaymentAmount = repaymentMonths > 0
+            ? totalPrincipal.divide(BigDecimal.valueOf(repaymentMonths), 0, RoundingMode.UP)
+            : totalPrincipal;
+
+        return new MyLoanSummaryResponse(
+            null,
+            application.getApplicationStatus(),
+            totalPrincipal,
+            totalPrincipal,
+            BigDecimal.ZERO,
+            interestRate,
+            startDate,
+            startDate.plusMonths(repaymentMonths),
+            startDate.plusMonths(1),
+            nextPaymentAmount,
+            BigDecimal.ZERO,
+            null
+        );
+    }
+
+    private LoanApplication ensureDisplayableLoanExists(Long memberId) {
+        return loanApplicationRepository.findTopByMember_MemberIdOrderByAppliedAtDesc(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("?異?愿由??뺣낫媛 ?놁뒿?덈떎."));
     }
 
     private LoanHistory getLatestLoanHistory(Long memberId) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #54 

---

### 📝 작업 내용
- 자격증 OCR 제출 흐름을 대출 신청 서류 제출이 아닌 우대금리 인증 상태로 분리
- 대출 신청 요약 응답에 우대금리 인증 상태 필드를 추가
- OCR 업로드 API에서 `loanApplicationId`를 정식 파라미터로 처리하고 중복 인증 완료 자격증 업로드를 방지
---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대출 신청서 요약에 우대금리 인증 가능 여부·제출 여부·상태가 추가됨
* **버그 수정 / 검증**
  * 이미 인증된 자격증의 중복 제출을 차단하는 검증 로직 추가
* **리팩토링**
  * 대출 식별자 처리 개선(신·구 식별자 허용) 및 자격증 제출 조회 방식 개선
* **동작 변경**
  * 대기 중인 대출은 요약·일정·이력 조회에서 별도 경로로 처리되어 표시 방식이 변경됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->