### PR TITLE
Refactor: final baseline에서 avg_spending 분리하고 연령/개인 가중치 로직 개선

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/finance/dto/FinalBaselineResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/dto/FinalBaselineResponse.java
@@ -20,7 +20,8 @@ public class FinalBaselineResponse {
     private LocalDate baselineEndDate;
     private Integer usageDays;
 
-    private BigDecimal avgSpending;
+    private BigDecimal ageAvgSpending;
+    private BigDecimal personalAvgSpending;
     private BigDecimal essentialRatio;
     private BigDecimal normalRatio;
     private BigDecimal discretionaryRatio;

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentPolicyService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentPolicyService.java
@@ -131,7 +131,7 @@ public class AutoRepaymentPolicyService {
             ratio = ratio.subtract(new BigDecimal("0.05"));
         }
 
-        BigDecimal avgSpending = nullSafe(finalBaseline.getAvgSpending());
+        BigDecimal avgSpending = resolvePolicyAvgSpending(finalBaseline);
         BigDecimal volatility = nullSafe(finalBaseline.getVolatility());
         if (avgSpending.compareTo(ZERO) > 0) {
             BigDecimal volatilityRatio = volatility.divide(avgSpending, 4, RoundingMode.HALF_UP);
@@ -154,7 +154,7 @@ public class AutoRepaymentPolicyService {
         List<String> reasons = new ArrayList<>();
 
         BigDecimal availableBalance = nullSafe(financialStatus.getAvailableBalance());
-        BigDecimal avgSpending = nullSafe(finalBaseline.getAvgSpending());
+        BigDecimal avgSpending = resolvePolicyAvgSpending(finalBaseline);
         BigDecimal monthlyIncome = nullSafe(financialStatus.getMonthlyIncome());
         BigDecimal currentMonthSpendingAmount = nullSafe(financialStatus.getCurrentMonthSpendingAmount());
         BigDecimal totalLoanRemainingPrincipal = nullSafe(financialStatus.getTotalLoanRemainingPrincipal());
@@ -214,6 +214,17 @@ public class AutoRepaymentPolicyService {
                 : String.join(", ", reasons);
 
         return new PolicyOutcome(adjustedRatio, action, grade, reason);
+    }
+
+    private BigDecimal resolvePolicyAvgSpending(FinalBaselineResponse finalBaseline) {
+        BigDecimal personalAvgSpending = nullSafe(finalBaseline.getPersonalAvgSpending());
+        BigDecimal ageAvgSpending = nullSafe(finalBaseline.getAgeAvgSpending());
+
+        if (nullSafe(finalBaseline.getPersonalBaselineWeight()).compareTo(ZERO) > 0
+                && personalAvgSpending.compareTo(ZERO) > 0) {
+            return personalAvgSpending;
+        }
+        return ageAvgSpending;
     }
 
     private String resolveAction(BigDecimal ratio) {

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/PersonalBaselineService.java
@@ -89,13 +89,15 @@ public class PersonalBaselineService {
                 .baselineStartDate(baselineStartDate)
                 .baselineEndDate(today)
                 .usageDays((int) ChronoUnit.DAYS.between(firstTransactionDate, today))
-                .avgSpending(weighted(ageBaseline.getAvgSpending(), personal.avgSpending(), weight))
+                .ageAvgSpending(ageBaseline.getAvgSpending())
+                .personalAvgSpending(personal.avgSpending())
                 .essentialRatio(weighted(ageBaseline.getEssentialRatio(), personal.essentialRatio(), weight))
                 .normalRatio(weighted(ageBaseline.getNormalRatio(), personal.normalRatio(), weight))
                 .discretionaryRatio(weighted(ageBaseline.getDiscretionaryRatio(), personal.discretionaryRatio(), weight))
                 .riskRatio(weighted(ageBaseline.getRiskRatio(), personal.riskRatio(), weight))
                 .volatility(weighted(ageBaseline.getVolatility(), personal.volatility(), weight))
                 .baselineSource(weight.personalWeight().compareTo(BigDecimal.ZERO) == 0 ? "AGE_ONLY"
+                        : weight.ageWeight().compareTo(BigDecimal.ZERO) == 0 ? "PERSONAL_ONLY"
                         : weight.personalWeight().compareTo(new BigDecimal("0.7")) >= 0 ? "PERSONAL_HEAVY"
                         : "MIXED")
                 .financialStatusResponse(financialStatus)
@@ -188,7 +190,8 @@ public class PersonalBaselineService {
                 .age(age)
                 .ageBaselineWeight(BigDecimal.ONE)
                 .personalBaselineWeight(BigDecimal.ZERO)
-                .avgSpending(baseline.getAvgSpending())
+                .ageAvgSpending(baseline.getAvgSpending())
+                .personalAvgSpending(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP))
                 .essentialRatio(baseline.getEssentialRatio())
                 .normalRatio(baseline.getNormalRatio())
                 .discretionaryRatio(baseline.getDiscretionaryRatio())
@@ -200,17 +203,23 @@ public class PersonalBaselineService {
     }
 
     private Weight resolveWeight(LocalDate firstTransactionDate, LocalDate today) {
-        long usageDays = Math.max(0, ChronoUnit.DAYS.between(firstTransactionDate, today));
-        if (usageDays < 30) {
-            return new Weight(new BigDecimal("0.9"), new BigDecimal("0.1"));
+        long usageMonths = Math.max(0, ChronoUnit.MONTHS.between(firstTransactionDate.withDayOfMonth(1), today.withDayOfMonth(1)));
+        if (usageMonths < 1) {
+            return new Weight(BigDecimal.ONE, BigDecimal.ZERO);
         }
-        if (usageDays < 90) {
+        if (usageMonths < 2) {
+            return new Weight(new BigDecimal("0.8"), new BigDecimal("0.2"));
+        }
+        if (usageMonths < 3) {
             return new Weight(new BigDecimal("0.6"), new BigDecimal("0.4"));
         }
-        if (usageDays < 180) {
-            return new Weight(new BigDecimal("0.3"), new BigDecimal("0.7"));
+        if (usageMonths < 4) {
+            return new Weight(new BigDecimal("0.4"), new BigDecimal("0.6"));
         }
-        return new Weight(new BigDecimal("0.1"), new BigDecimal("0.9"));
+        if (usageMonths < 5) {
+            return new Weight(new BigDecimal("0.2"), new BigDecimal("0.8"));
+        }
+        return new Weight(BigDecimal.ZERO, BigDecimal.ONE);
     }
 
     private BigDecimal weighted(BigDecimal ageValue, BigDecimal personalValue, Weight weight) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #58 

---

### 📝 작업 내용
- 무엇을 / 왜 / 어떻게 수정했는지 간단히 작성

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 개인별 및 연령대별 지출 패턴을 모두 고려하여 지출 기준선 계산 로직을 강화했습니다.
  * 월 단위 기반의 더욱 정확한 가중치 계산으로 자동 상환 정책이 개선되었습니다.
  * 개인 지출 데이터의 가용성에 따라 기준선 선택 로직이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->