### PR TITLE
Feat: 카드 결제 후 자동상환 실행 및 결제 응답 확장

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/card/controller/CardPaymentController.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/controller/CardPaymentController.java
@@ -2,6 +2,7 @@ package com.nudgebank.bankbackend.card.controller;
 
 import com.nudgebank.bankbackend.auth.security.SecurityUtil;
 import com.nudgebank.bankbackend.card.dto.CardPaymentRequest;
+import com.nudgebank.bankbackend.card.dto.CardPaymentResponse;
 import com.nudgebank.bankbackend.card.service.CardPaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/cards")
@@ -23,7 +22,7 @@ public class CardPaymentController {
     private final CardPaymentService cardPaymentService;
 
     @PostMapping("/payment")
-    public ResponseEntity<Map<String, Long>> pay(
+    public ResponseEntity<CardPaymentResponse> pay(
             @RequestBody CardPaymentRequest request,
             Authentication authentication
     ) {
@@ -31,7 +30,7 @@ public class CardPaymentController {
         if (userId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        Long transactionId = cardPaymentService.processPayment(request);
-        return ResponseEntity.ok(Map.of("transactionId", transactionId));
+        CardPaymentResponse response = cardPaymentService.processPayment(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/card/dto/CardPaymentResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/dto/CardPaymentResponse.java
@@ -1,0 +1,30 @@
+package com.nudgebank.bankbackend.card.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class CardPaymentResponse {
+
+    private Long transactionId;
+    // 카드 결제 거래 ID
+    private BigDecimal paymentAmount;
+    // 결제 금액
+    private Boolean autoRepaymentApplied;
+    // 결제 직후 자동상환이 실제 적용되었는지 여부
+    private String repaymentAction;
+    // 자동상환 정책 엔진이 결정한 액션 (예: HOLD, STANDARD)
+    private String policyGrade;
+    // 자동상환 정책 등급 (예: NO_LOAN, BALANCED)
+    private BigDecimal repaymentRate;
+    // 실제 적용된 자동상환 비율
+    private BigDecimal repaymentAmount;
+    // 결제 직후 추가로 차감된 자동상환 금액
+    private BigDecimal remainingLoanBalance;
+    // 자동상환 반영 후 남은 대출 원금
+    private BigDecimal totalDebitedAmount;
+    // 결제금액 + 자동상환금액을 합한 총 차감 금액
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
@@ -7,10 +7,13 @@ import com.nudgebank.bankbackend.card.domain.CardTransaction;
 import com.nudgebank.bankbackend.card.domain.Market;
 import com.nudgebank.bankbackend.card.domain.MarketCategory;
 import com.nudgebank.bankbackend.card.dto.CardPaymentRequest;
+import com.nudgebank.bankbackend.card.dto.CardPaymentResponse;
 import com.nudgebank.bankbackend.card.repository.CardRepository;
 import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
 import com.nudgebank.bankbackend.card.repository.MarketCategoryRepository;
 import com.nudgebank.bankbackend.card.repository.MarketRepository;
+import com.nudgebank.bankbackend.finance.service.AutoRepaymentExecutionService.AutoRepaymentExecutionResult;
+import com.nudgebank.bankbackend.finance.service.AutoRepaymentExecutionService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,8 +32,9 @@ public class CardPaymentService {
     private final MarketRepository marketRepository;
     private final MarketCategoryRepository marketCategoryRepository;
     private final CardTransactionRepository cardTransactionRepository;
+    private final AutoRepaymentExecutionService autoRepaymentExecutionService;
 
-    public Long processPayment(CardPaymentRequest request) {
+    public CardPaymentResponse processPayment(CardPaymentRequest request) {
         validateRequest(request);
 
         Card card = cardRepository.findById(request.cardId())
@@ -75,7 +79,22 @@ public class CardPaymentService {
                 .build();
 
         CardTransaction saved = cardTransactionRepository.save(transaction);
-        return saved.getTransactionId();
+        AutoRepaymentExecutionResult autoRepaymentResult =
+                autoRepaymentExecutionService.executeAfterPayment(account.getMemberId(), saved);
+
+        BigDecimal totalDebitedAmount = request.amount().add(autoRepaymentResult.repaymentAmount());
+
+        return CardPaymentResponse.builder()
+                .transactionId(saved.getTransactionId())
+                .paymentAmount(request.amount())
+                .autoRepaymentApplied(autoRepaymentResult.autoRepaymentApplied())
+                .repaymentAction(autoRepaymentResult.repaymentAction())
+                .policyGrade(autoRepaymentResult.policyGrade())
+                .repaymentRate(autoRepaymentResult.repaymentRate())
+                .repaymentAmount(autoRepaymentResult.repaymentAmount())
+                .remainingLoanBalance(autoRepaymentResult.remainingLoanBalance())
+                .totalDebitedAmount(totalDebitedAmount)
+                .build();
     }
 
     private void validateRequest(CardPaymentRequest request) {

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardPaymentService.java
@@ -79,8 +79,12 @@ public class CardPaymentService {
                 .build();
 
         CardTransaction saved = cardTransactionRepository.save(transaction);
-        AutoRepaymentExecutionResult autoRepaymentResult =
-                autoRepaymentExecutionService.executeAfterPayment(account.getMemberId(), saved);
+        AutoRepaymentExecutionResult autoRepaymentResult;
+        try {
+            autoRepaymentResult = autoRepaymentExecutionService.executeAfterPayment(account.getMemberId(), saved);
+        } catch (RuntimeException exception) {
+            autoRepaymentResult = AutoRepaymentExecutionResult.failed();
+        }
 
         BigDecimal totalDebitedAmount = request.amount().add(autoRepaymentResult.repaymentAmount());
 

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentExecutionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentExecutionService.java
@@ -13,11 +13,11 @@ import java.math.RoundingMode;
 import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AutoRepaymentExecutionService {
 
     private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
@@ -28,6 +28,7 @@ public class AutoRepaymentExecutionService {
     private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
     private final AccountRepository accountRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public AutoRepaymentExecutionResult executeAfterPayment(Long memberId, CardTransaction transaction) {
         LoanHistory loanHistory = loanHistoryRepository
                 .findByCard_CardIdAndStatus(transaction.getCard().getCardId(), "ACTIVE")
@@ -110,7 +111,7 @@ public class AutoRepaymentExecutionService {
             BigDecimal repaymentAmount,
             BigDecimal remainingLoanBalance
     ) {
-        private static AutoRepaymentExecutionResult notApplied() {
+        public static AutoRepaymentExecutionResult notApplied() {
             return new AutoRepaymentExecutionResult(
                     false,
                     null,
@@ -121,7 +122,18 @@ public class AutoRepaymentExecutionService {
             );
         }
 
-        private static AutoRepaymentExecutionResult fromDecision(
+        public static AutoRepaymentExecutionResult failed() {
+            return new AutoRepaymentExecutionResult(
+                    false,
+                    "HOLD",
+                    "FAILED",
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    null
+            );
+        }
+
+        public static AutoRepaymentExecutionResult fromDecision(
                 AutoRepaymentDecisionResponse decision,
                 BigDecimal repaymentAmount,
                 BigDecimal remainingLoanBalance,

--- a/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentExecutionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentExecutionService.java
@@ -1,0 +1,144 @@
+package com.nudgebank.bankbackend.finance.service;
+
+import com.nudgebank.bankbackend.account.domain.Account;
+import com.nudgebank.bankbackend.account.repository.AccountRepository;
+import com.nudgebank.bankbackend.card.domain.CardTransaction;
+import com.nudgebank.bankbackend.finance.dto.AutoRepaymentDecisionResponse;
+import com.nudgebank.bankbackend.loan.domain.LoanHistory;
+import com.nudgebank.bankbackend.loan.domain.LoanRepaymentHistory;
+import com.nudgebank.bankbackend.loan.repository.LoanHistoryRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanRepaymentHistoryRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AutoRepaymentExecutionService {
+
+    private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    private static final BigDecimal ONE_HUNDRED = new BigDecimal("100");
+
+    private final AutoRepaymentPolicyService autoRepaymentPolicyService;
+    private final LoanHistoryRepository loanHistoryRepository;
+    private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
+    private final AccountRepository accountRepository;
+
+    public AutoRepaymentExecutionResult executeAfterPayment(Long memberId, CardTransaction transaction) {
+        LoanHistory loanHistory = loanHistoryRepository
+                .findByCard_CardIdAndStatus(transaction.getCard().getCardId(), "ACTIVE")
+                .orElse(null);
+
+        if (loanHistory == null) {
+            return AutoRepaymentExecutionResult.notApplied();
+        }
+
+        AutoRepaymentDecisionResponse decision = autoRepaymentPolicyService.decideAutoRepayment(
+                memberId,
+                transaction.getTransactionId()
+        );
+
+        BigDecimal ratio = nullSafe(decision.getFinalRepaymentRatio());
+        if (ratio.compareTo(BigDecimal.ZERO) <= 0) {
+            return AutoRepaymentExecutionResult.fromDecision(decision, BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    nullSafe(loanHistory.getRemainingPrincipal()), false);
+        }
+
+        Account account = accountRepository.findByIdForUpdate(transaction.getCard().getAccountId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "자동상환용 계좌를 찾을 수 없습니다. accountId=" + transaction.getCard().getAccountId()
+                ));
+
+        BigDecimal repaymentAmount = calculateRepaymentAmount(transaction.getAmount(), ratio, loanHistory);
+        if (repaymentAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return AutoRepaymentExecutionResult.fromDecision(decision, BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    nullSafe(loanHistory.getRemainingPrincipal()), false);
+        }
+
+        account.withdraw(repaymentAmount);
+        BigDecimal appliedAmount = loanHistory.applyRepayment(repaymentAmount);
+
+        loanRepaymentHistoryRepository.save(LoanRepaymentHistory.create(
+                loanHistory,
+                transaction,
+                appliedAmount,
+                toPercent(ratio),
+                OffsetDateTime.now(),
+                loanHistory.getRemainingPrincipal()
+        ));
+
+        return AutoRepaymentExecutionResult.fromDecision(
+                decision,
+                appliedAmount,
+                nullSafe(loanHistory.getRemainingPrincipal()),
+                appliedAmount.compareTo(BigDecimal.ZERO) > 0
+        );
+    }
+
+    private BigDecimal calculateRepaymentAmount(
+            BigDecimal transactionAmount,
+            BigDecimal ratio,
+            LoanHistory loanHistory
+    ) {
+        BigDecimal requestedAmount = nullSafe(transactionAmount)
+                .multiply(ratio)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        BigDecimal remainingPrincipal = nullSafe(loanHistory.getRemainingPrincipal());
+        return requestedAmount.min(remainingPrincipal).max(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+    }
+
+    private BigDecimal toPercent(BigDecimal ratio) {
+        return nullSafe(ratio)
+                .multiply(ONE_HUNDRED)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return value == null ? ZERO : value;
+    }
+
+    public record AutoRepaymentExecutionResult(
+            boolean autoRepaymentApplied,
+            String repaymentAction,
+            String policyGrade,
+            BigDecimal repaymentRate,
+            BigDecimal repaymentAmount,
+            BigDecimal remainingLoanBalance
+    ) {
+        private static AutoRepaymentExecutionResult notApplied() {
+            return new AutoRepaymentExecutionResult(
+                    false,
+                    null,
+                    null,
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    null
+            );
+        }
+
+        private static AutoRepaymentExecutionResult fromDecision(
+                AutoRepaymentDecisionResponse decision,
+                BigDecimal repaymentAmount,
+                BigDecimal remainingLoanBalance,
+                boolean applied
+        ) {
+            BigDecimal repaymentRate = decision.getFinalRepaymentRatio() == null
+                    ? BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+                    : decision.getFinalRepaymentRatio().multiply(ONE_HUNDRED).setScale(2, RoundingMode.HALF_UP);
+
+            return new AutoRepaymentExecutionResult(
+                    applied,
+                    decision.getRepaymentAction(),
+                    decision.getPolicyGrade(),
+                    repaymentRate,
+                    repaymentAmount,
+                    remainingLoanBalance
+            );
+        }
+    }
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
@@ -69,7 +69,7 @@ public class LoanHistory {
         if (this.remainingPrincipal.compareTo(BigDecimal.ZERO) <= 0) {
             this.remainingPrincipal = BigDecimal.ZERO;
             this.status = "COMPLETED";
-            this.expectedRepaymentDate = LocalDate.now();
+            this.endDate = LocalDate.now();
         }
 
         return appliedAmount;

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
@@ -53,4 +53,25 @@ public class LoanHistory {
 
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
+
+    public BigDecimal applyRepayment(BigDecimal repaymentAmount) {
+        if (repaymentAmount == null || repaymentAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("상환 금액은 0보다 커야 합니다.");
+        }
+
+        BigDecimal currentRemainingPrincipal = this.remainingPrincipal != null
+                ? this.remainingPrincipal
+                : BigDecimal.ZERO;
+
+        BigDecimal appliedAmount = repaymentAmount.min(currentRemainingPrincipal);
+        this.remainingPrincipal = currentRemainingPrincipal.subtract(appliedAmount);
+
+        if (this.remainingPrincipal.compareTo(BigDecimal.ZERO) <= 0) {
+            this.remainingPrincipal = BigDecimal.ZERO;
+            this.status = "COMPLETED";
+            this.expectedRepaymentDate = LocalDate.now();
+        }
+
+        return appliedAmount;
+    }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
@@ -40,4 +40,38 @@ public class LoanRepaymentHistory {
 
     @Column(name = "remaining_balance", precision = 15, scale = 2)
     private BigDecimal remainingBalance;
+
+    private LoanRepaymentHistory(
+            LoanHistory loanHistory,
+            CardTransaction transaction,
+            BigDecimal repaymentAmount,
+            BigDecimal repaymentRate,
+            OffsetDateTime repaymentDatetime,
+            BigDecimal remainingBalance
+    ) {
+        this.loanHistory = loanHistory;
+        this.transaction = transaction;
+        this.repaymentAmount = repaymentAmount;
+        this.repaymentRate = repaymentRate;
+        this.repaymentDatetime = repaymentDatetime;
+        this.remainingBalance = remainingBalance;
+    }
+
+    public static LoanRepaymentHistory create(
+            LoanHistory loanHistory,
+            CardTransaction transaction,
+            BigDecimal repaymentAmount,
+            BigDecimal repaymentRate,
+            OffsetDateTime repaymentDatetime,
+            BigDecimal remainingBalance
+    ) {
+        return new LoanRepaymentHistory(
+                loanHistory,
+                transaction,
+                repaymentAmount,
+                repaymentRate,
+                repaymentDatetime,
+                remainingBalance
+        );
+    }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
@@ -1,22 +1,13 @@
 package com.nudgebank.bankbackend.loan.domain;
 
 import com.nudgebank.bankbackend.card.domain.CardTransaction;
-import jakarta.persistence.Access;
-import jakarta.persistence.AccessType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.math.BigDecimal;
-import java.time.OffsetDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "loan_repayment_history")
@@ -50,6 +41,37 @@ public class LoanRepaymentHistory {
     @Column(name = "remaining_balance", precision = 15, scale = 2)
     private BigDecimal remainingBalance;
 
-    @Column(name = "\"Key\"")
-    private String recordKey;
+    private LoanRepaymentHistory(
+            LoanHistory loanHistory,
+            CardTransaction transaction,
+            BigDecimal repaymentAmount,
+            BigDecimal repaymentRate,
+            OffsetDateTime repaymentDatetime,
+            BigDecimal remainingBalance
+    ) {
+        this.loanHistory = loanHistory;
+        this.transaction = transaction;
+        this.repaymentAmount = repaymentAmount;
+        this.repaymentRate = repaymentRate;
+        this.repaymentDatetime = repaymentDatetime;
+        this.remainingBalance = remainingBalance;
+    }
+
+    public static LoanRepaymentHistory create(
+            LoanHistory loanHistory,
+            CardTransaction transaction,
+            BigDecimal repaymentAmount,
+            BigDecimal repaymentRate,
+            OffsetDateTime repaymentDatetime,
+            BigDecimal remainingBalance
+    ) {
+        return new LoanRepaymentHistory(
+                loanHistory,
+                transaction,
+                repaymentAmount,
+                repaymentRate,
+                repaymentDatetime,
+                remainingBalance
+        );
+    }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -1,25 +1,22 @@
 package com.nudgebank.bankbackend.loan.service;
 
-import com.nudgebank.bankbackend.loan.domain.LoanHistory;
 import com.nudgebank.bankbackend.loan.domain.Loan;
 import com.nudgebank.bankbackend.loan.domain.LoanApplication;
+import com.nudgebank.bankbackend.loan.domain.LoanHistory;
 import com.nudgebank.bankbackend.loan.domain.RepaymentSchedule;
 import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentHistoryResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentScheduleResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanSummaryResponse;
-import com.nudgebank.bankbackend.loan.repository.LoanApplicationRepository;
-import com.nudgebank.bankbackend.loan.repository.LoanHistoryRepository;
-import com.nudgebank.bankbackend.loan.repository.LoanRepository;
-import com.nudgebank.bankbackend.loan.repository.LoanRepaymentHistoryRepository;
-import com.nudgebank.bankbackend.loan.repository.RepaymentScheduleRepository;
+import com.nudgebank.bankbackend.loan.repository.*;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -148,7 +145,7 @@ public class MyLoanManagementService {
 
     private LoanApplication ensureDisplayableLoanExists(Long memberId) {
         return loanApplicationRepository.findTopByMember_MemberIdOrderByAppliedAtDesc(memberId)
-            .orElseThrow(() -> new EntityNotFoundException("?異?愿由??뺣낫媛 ?놁뒿?덈떎."));
+            .orElseThrow(() -> new EntityNotFoundException("대출 상품이 없습니다."));
     }
 
     private LoanHistory getLatestLoanHistory(Long memberId) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #76 

---

### 📝 작업 내용
- 카드 결제 후 자동상환이 실제로 반영되고 결제 응답만으로도 상환 결과를 함께 확인할 수 있도록 함

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 응답 확장: 거래 ID, 결제금액 및 자동상환 적용 여부·정책 등급·상환율·상환액·잔여원금·총 차감금액 등 상세 정보 반환
  * 결제 직후 자동상환 실행을 별도 처리로 수행하고 그 결과를 결제 응답에 포함

* **버그 수정 / 개선**
  * 상환 적용 및 기록 강화: 대출 잔액·상태 업데이트와 상환 이력 생성 로직 보완으로 처리 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->