### PR TITLE
[Deploy] cors 허용 리스트에 도메인 url 추가

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration config = new CorsConfiguration();
-    config.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173"));
+    config.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173", "https://nudgebank.shinhanacademy.co.kr"));
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     config.setAllowedHeaders(List.of("Content-Type", "Authorization"));
     config.setAllowCredentials(true);


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #75 

---

### 📝 작업 내용
- 아카데미에서 제공해준 도메인 url을 cors 허용 목록에 추가하였습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CORS 설정을 업데이트하여 추가 도메인(`https://nudgebank.shinhanacademy.co.kr`)에서의 접근을 허용하도록 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->