### PR TITLE
Feat: 카드 이용내역 조회에 자동상환 이력 포함

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/card/dto/CardHistoryResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/dto/CardHistoryResponse.java
@@ -29,7 +29,12 @@ public record CardHistoryResponse(
       BigDecimal amount,
       String transactionDatetime,
       String menuName,
-      Integer quantity
+      Integer quantity,
+      Boolean autoRepaymentApplied,
+      BigDecimal repaymentRate,
+      BigDecimal repaymentAmount,
+      String repaymentDatetime,
+      BigDecimal remainingLoanBalance
   ) {
   }
 }

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardHistoryService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardHistoryService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -77,10 +78,9 @@ public class CardHistoryService {
         .findByTransaction_TransactionIdIn(
             transactions.stream().map(CardTransaction::getTransactionId).toList()
         ).stream()
-        .collect(java.util.stream.Collectors.toMap(
+        .collect(Collectors.toMap(
             history -> history.getTransaction().getTransactionId(),
-            Function.identity(),
-            (existing, replacement) -> existing
+            Function.identity()
         ));
 
     return new CardHistoryResponse.CardHistoryAccountDto(

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardHistoryService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardHistoryService.java
@@ -7,13 +7,17 @@ import com.nudgebank.bankbackend.card.domain.CardTransaction;
 import com.nudgebank.bankbackend.card.dto.CardHistoryResponse;
 import com.nudgebank.bankbackend.card.repository.CardRepository;
 import com.nudgebank.bankbackend.card.repository.CardTransactionRepository;
+import com.nudgebank.bankbackend.loan.domain.LoanRepaymentHistory;
+import com.nudgebank.bankbackend.loan.repository.LoanRepaymentHistoryRepository;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,15 +27,18 @@ public class CardHistoryService {
   private final AccountRepository accountRepository;
   private final CardRepository cardRepository;
   private final CardTransactionRepository cardTransactionRepository;
+  private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
 
   public CardHistoryService(
       AccountRepository accountRepository,
       CardRepository cardRepository,
-      CardTransactionRepository cardTransactionRepository
+      CardTransactionRepository cardTransactionRepository,
+      LoanRepaymentHistoryRepository loanRepaymentHistoryRepository
   ) {
     this.accountRepository = accountRepository;
     this.cardRepository = cardRepository;
     this.cardTransactionRepository = cardTransactionRepository;
+    this.loanRepaymentHistoryRepository = loanRepaymentHistoryRepository;
   }
 
   public CardHistoryResponse getHistory(Long userId) {
@@ -66,6 +73,15 @@ public class CardHistoryService {
     Card card = cardOptional.get();
     List<CardTransaction> transactions =
         cardTransactionRepository.findByCardCardIdOrderByTransactionDatetimeDesc(card.getCardId());
+    Map<Long, LoanRepaymentHistory> repaymentHistoryByTransactionId = loanRepaymentHistoryRepository
+        .findByTransaction_TransactionIdIn(
+            transactions.stream().map(CardTransaction::getTransactionId).toList()
+        ).stream()
+        .collect(java.util.stream.Collectors.toMap(
+            history -> history.getTransaction().getTransactionId(),
+            Function.identity(),
+            (existing, replacement) -> existing
+        ));
 
     return new CardHistoryResponse.CardHistoryAccountDto(
         account.getAccountId(),
@@ -77,15 +93,24 @@ public class CardHistoryService {
         card.getExpiredYm(),
         card.getStatus(),
         calculateSpentThisMonth(card.getCardId()),
-        transactions.stream().map(this::toTransactionDto).toList()
+        transactions.stream().map(transaction -> toTransactionDto(
+            transaction,
+            repaymentHistoryByTransactionId.get(transaction.getTransactionId())
+        )).toList()
     );
   }
 
-  private CardHistoryResponse.CardHistoryTransactionDto toTransactionDto(CardTransaction transaction) {
+  private CardHistoryResponse.CardHistoryTransactionDto toTransactionDto(
+      CardTransaction transaction,
+      LoanRepaymentHistory repaymentHistory
+  ) {
     OffsetDateTime transactionDateTime = transaction.getTransactionDatetime();
     String formattedDateTime = transactionDateTime == null
         ? null
         : transactionDateTime.withOffsetSameInstant(ZoneOffset.ofHours(9)).format(DATE_TIME_FORMATTER);
+    String formattedRepaymentDateTime = repaymentHistory == null || repaymentHistory.getRepaymentDatetime() == null
+        ? null
+        : repaymentHistory.getRepaymentDatetime().withOffsetSameInstant(ZoneOffset.ofHours(9)).format(DATE_TIME_FORMATTER);
 
     return new CardHistoryResponse.CardHistoryTransactionDto(
         transaction.getTransactionId(),
@@ -94,7 +119,12 @@ public class CardHistoryService {
         transaction.getAmount(),
         formattedDateTime,
         transaction.getMenuName(),
-        transaction.getQuantity()
+        transaction.getQuantity(),
+        repaymentHistory != null,
+        repaymentHistory != null ? repaymentHistory.getRepaymentRate() : BigDecimal.ZERO,
+        repaymentHistory != null ? repaymentHistory.getRepaymentAmount() : BigDecimal.ZERO,
+        formattedRepaymentDateTime,
+        repaymentHistory != null ? repaymentHistory.getRemainingBalance() : null
     );
   }
 

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanRepaymentHistory.java
@@ -25,8 +25,8 @@ public class LoanRepaymentHistory {
     @JoinColumn(name = "loan_history_id", nullable = false)
     private LoanHistory loanHistory;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "transaction_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "transaction_id", nullable = false, unique = true)
     private CardTransaction transaction;
 
     @Column(name = "repayment_amount", precision = 15, scale = 2)

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepaymentHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepaymentHistoryRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LoanRepaymentHistoryRepository extends JpaRepository<LoanRepaymentHistory, Long> {
 
     List<LoanRepaymentHistory> findTop10ByLoanHistory_IdOrderByRepaymentDatetimeDesc(Long loanHistoryId);
+
+    List<LoanRepaymentHistory> findByTransaction_TransactionIdIn(List<Long> transactionIds);
 }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #79 

---

### 📝 작업 내용
- 카드 이용내역 조회에 자동상환 이력 포함

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 카드 거래 내역에 대출 상환 정보가 추가되었습니다 — 자동 상환 여부, 상환율, 상환액, 상환 일시, 남은 대출 잔액 등 상환 관련 상세 정보가 거래 항목에 함께 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->