### PR TITLE
Feat: 대출 상품 데이터 자동 초기화

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
@@ -24,6 +24,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                 "SELF_DEVELOPMENT",
                 "자기계발 대출",
                 "자격증 및 역량개발 지원 대출",
+                "자격증 취득과 직무 역량 개발이 필요한 청년 고객",
                 new BigDecimal("3.50"),
                 new BigDecimal("5.50"),
                 3_000_000L,
@@ -35,6 +36,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                 "CONSUMPTION_ANALYSIS",
                 "소비분석 대출",
                 "소비패턴 기반 맞춤 대출",
+                "소비 흐름 관리가 필요한 고객",
                 new BigDecimal("4.00"),
                 new BigDecimal("6.50"),
                 5_000_000L,
@@ -46,6 +48,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                 "EMERGENCY",
                 "긴급 대출",
                 "긴급 생활안정 자금 대출",
+                "단기 긴급 자금이 필요한 고객",
                 new BigDecimal("5.00"),
                 new BigDecimal("8.00"),
                 2_000_000L,
@@ -61,6 +64,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                     existing -> existing.updateProduct(
                         seed.loanProductName(),
                         seed.loanProductDescription(),
+                        seed.targetCustomer(),
                         seed.minInterestRate(),
                         seed.maxInterestRate(),
                         seed.maxLimitAmount(),
@@ -73,6 +77,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                             .loanProductType(seed.loanProductType())
                             .loanProductName(seed.loanProductName())
                             .loanProductDescription(seed.loanProductDescription())
+                            .targetCustomer(seed.targetCustomer())
                             .minInterestRate(seed.minInterestRate())
                             .maxInterestRate(seed.maxInterestRate())
                             .maxLimitAmount(seed.maxLimitAmount())
@@ -90,6 +95,7 @@ public class LoanProductInitializer implements CommandLineRunner {
         String loanProductType,
         String loanProductName,
         String loanProductDescription,
+        String targetCustomer,
         BigDecimal minInterestRate,
         BigDecimal maxInterestRate,
         Long maxLimitAmount,

--- a/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
@@ -1,0 +1,100 @@
+package com.nudgebank.bankbackend.loan.config;
+
+import com.nudgebank.bankbackend.loan.domain.LoanProduct;
+import com.nudgebank.bankbackend.loan.repository.LoanProductRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class LoanProductInitializer implements CommandLineRunner {
+
+    private final LoanProductRepository loanProductRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        List<LoanProductSeed> seeds = List.of(
+            new LoanProductSeed(
+                "SELF_DEVELOPMENT",
+                "자기계발 대출",
+                "자격증 및 역량개발 지원 대출",
+                new BigDecimal("3.50"),
+                new BigDecimal("5.50"),
+                3_000_000L,
+                500_000L,
+                12,
+                "EQUAL_INSTALLMENT"
+            ),
+            new LoanProductSeed(
+                "CONSUMPTION_ANALYSIS",
+                "소비분석 대출",
+                "소비패턴 기반 맞춤 대출",
+                new BigDecimal("4.00"),
+                new BigDecimal("6.50"),
+                5_000_000L,
+                500_000L,
+                12,
+                "EQUAL_INSTALLMENT"
+            ),
+            new LoanProductSeed(
+                "EMERGENCY",
+                "긴급 대출",
+                "긴급 생활안정 자금 대출",
+                new BigDecimal("5.00"),
+                new BigDecimal("8.00"),
+                2_000_000L,
+                300_000L,
+                6,
+                "EQUAL_INSTALLMENT"
+            )
+        );
+
+        for (LoanProductSeed seed : seeds) {
+            loanProductRepository.findByLoanProductType(seed.loanProductType())
+                .ifPresentOrElse(
+                    existing -> existing.updateProduct(
+                        seed.loanProductName(),
+                        seed.loanProductDescription(),
+                        seed.minInterestRate(),
+                        seed.maxInterestRate(),
+                        seed.maxLimitAmount(),
+                        seed.minLimitAmount(),
+                        seed.repaymentPeriodMonth(),
+                        seed.repaymentType()
+                    ),
+                    () -> loanProductRepository.save(
+                        LoanProduct.builder()
+                            .loanProductType(seed.loanProductType())
+                            .loanProductName(seed.loanProductName())
+                            .loanProductDescription(seed.loanProductDescription())
+                            .minInterestRate(seed.minInterestRate())
+                            .maxInterestRate(seed.maxInterestRate())
+                            .maxLimitAmount(seed.maxLimitAmount())
+                            .minLimitAmount(seed.minLimitAmount())
+                            .repaymentPeriodMonth(seed.repaymentPeriodMonth())
+                            .repaymentType(seed.repaymentType())
+                            .createdAt(LocalDateTime.now())
+                            .build()
+                    )
+                );
+        }
+    }
+
+    private record LoanProductSeed(
+        String loanProductType,
+        String loanProductName,
+        String loanProductDescription,
+        BigDecimal minInterestRate,
+        BigDecimal maxInterestRate,
+        Long maxLimitAmount,
+        Long minLimitAmount,
+        Integer repaymentPeriodMonth,
+        String repaymentType
+    ) {}
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanProduct.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanProduct.java
@@ -54,4 +54,24 @@ public class LoanProduct {
     @OneToMany(mappedBy = "loanProduct")
     @Builder.Default
     private List<LoanApplication> loanApplications = new ArrayList<>();
+
+    public void updateProduct(
+        String loanProductName,
+        String loanProductDescription,
+        BigDecimal minInterestRate,
+        BigDecimal maxInterestRate,
+        Long maxLimitAmount,
+        Long minLimitAmount,
+        Integer repaymentPeriodMonth,
+        String repaymentType
+    ) {
+        this.loanProductName = loanProductName;
+        this.loanProductDescription = loanProductDescription;
+        this.minInterestRate = minInterestRate;
+        this.maxInterestRate = maxInterestRate;
+        this.maxLimitAmount = maxLimitAmount;
+        this.minLimitAmount = minLimitAmount;
+        this.repaymentPeriodMonth = repaymentPeriodMonth;
+        this.repaymentType = repaymentType;
+    }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanProduct.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanProduct.java
@@ -27,6 +27,9 @@ public class LoanProduct {
     @Column(name = "loan_product_description", columnDefinition = "TEXT")
     private String loanProductDescription;
 
+    @Column(name = "target_customer", length = 200)
+    private String targetCustomer;
+
     @Column(name = "min_interest_rate", precision = 5, scale = 2)
     private BigDecimal minInterestRate;
 
@@ -58,6 +61,7 @@ public class LoanProduct {
     public void updateProduct(
         String loanProductName,
         String loanProductDescription,
+        String targetCustomer,
         BigDecimal minInterestRate,
         BigDecimal maxInterestRate,
         Long maxLimitAmount,
@@ -67,6 +71,7 @@ public class LoanProduct {
     ) {
         this.loanProductName = loanProductName;
         this.loanProductDescription = loanProductDescription;
+        this.targetCustomer = targetCustomer;
         this.minInterestRate = minInterestRate;
         this.maxInterestRate = maxInterestRate;
         this.maxLimitAmount = maxLimitAmount;


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #81 

---

### 📝 작업 내용
- 서버 실행 시 `loan_product` 기본 데이터가 자동으로 초기화되도록 시드 로직 추가
- `loan_product_type` 기준으로 기존 상품이 없으면 insert, 있으면 기준 데이터로 update 되도록 처리
- 팀원 로컬 환경마다 대출 상품 데이터가 다르게 보이던 문제를 줄이도록 마스터 데이터 초기화 흐름 정리

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 애플리케이션 시작 시 미리 정의된 대출 상품(3종)이 자동으로 생성되거나 기존 항목이 업데이트됩니다.
  * 각 대출 상품에 대상 고객(target customer) 정보가 추가되어 상품 정보에 대상 고객 설명이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->