### PR TITLE
Feat: OCR 자격증 마스터 데이터 자동 초기화

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/config/CertificateMasterInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/config/CertificateMasterInitializer.java
@@ -1,0 +1,79 @@
+package com.nudgebank.bankbackend.certificate.config;
+
+import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
+import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CertificateMasterInitializer implements CommandLineRunner {
+
+    private final CertificateMasterRepository certificateMasterRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        List<CertificateSeed> seeds = List.of(
+            new CertificateSeed(1L, "컴퓨터활용능력 1급", "대한상공회의소"),
+            new CertificateSeed(2L, "컴퓨터활용능력 2급", "대한상공회의소"),
+            new CertificateSeed(3L, "워드프로세서", "대한상공회의소"),
+            new CertificateSeed(4L, "한국사능력검정시험", "국사편찬위원회"),
+            new CertificateSeed(5L, "정보처리기사", "한국산업인력공단"),
+            new CertificateSeed(6L, "정보처리산업기사", "한국산업인력공단"),
+            new CertificateSeed(7L, "ADsP", "한국데이터산업진흥원"),
+            new CertificateSeed(8L, "SQLD", "한국데이터산업진흥원"),
+            new CertificateSeed(9L, "빅데이터분석기사", "한국데이터산업진흥원"),
+            new CertificateSeed(10L, "전산회계 1급", "한국세무사회"),
+            new CertificateSeed(11L, "전산세무 2급", "한국세무사회"),
+            new CertificateSeed(12L, "투자자산운용사", "한국금융투자협회"),
+            new CertificateSeed(13L, "AFPK", "한국FPSB"),
+            new CertificateSeed(14L, "신용분석사", "한국금융연수원"),
+            new CertificateSeed(18L, "JLPT", "국제교류기금"),
+            new CertificateSeed(19L, "HSK", "중국국가한판"),
+            new CertificateSeed(20L, "공인중개사", "한국산업인력공단"),
+            new CertificateSeed(21L, "감정평가사", "한국감정평가사협회"),
+            new CertificateSeed(22L, "세무사", "한국산업인력공단"),
+            new CertificateSeed(23L, "공인회계사", "금융감독원"),
+            new CertificateSeed(24L, "변호사", "대한변호사협회"),
+            new CertificateSeed(25L, "전기기사", "한국산업인력공단"),
+            new CertificateSeed(26L, "산업안전기사", "한국산업인력공단"),
+            new CertificateSeed(27L, "건축기사", "한국산업인력공단"),
+            new CertificateSeed(28L, "토목기사", "한국산업인력공단"),
+            new CertificateSeed(29L, "기계기사", "한국산업인력공단")
+        );
+
+        for (CertificateSeed seed : seeds) {
+            certificateMasterRepository.findById(seed.certificateId())
+                .ifPresentOrElse(
+                    existing -> existing.updateMaster(
+                        seed.certificateName(),
+                        seed.issuerName(),
+                        BigDecimal.ZERO,
+                        true
+                    ),
+                    () -> certificateMasterRepository.save(
+                        CertificateMaster.create(
+                            seed.certificateId(),
+                            seed.certificateName(),
+                            seed.issuerName(),
+                            BigDecimal.ZERO,
+                            true,
+                            OffsetDateTime.now()
+                        )
+                    )
+                );
+        }
+    }
+
+    private record CertificateSeed(
+        Long certificateId,
+        String certificateName,
+        String issuerName
+    ) {}
+}

--- a/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateMaster.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/domain/CertificateMaster.java
@@ -35,4 +35,50 @@ public class CertificateMaster {
 
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
+
+    private CertificateMaster(
+        Long certificateId,
+        String certificateName,
+        String issuerName,
+        BigDecimal rateDiscount,
+        Boolean isActive,
+        OffsetDateTime createdAt
+    ) {
+        this.certificateId = certificateId;
+        this.certificateName = certificateName;
+        this.issuerName = issuerName;
+        this.rateDiscount = rateDiscount;
+        this.isActive = isActive;
+        this.createdAt = createdAt;
+    }
+
+    public static CertificateMaster create(
+        Long certificateId,
+        String certificateName,
+        String issuerName,
+        BigDecimal rateDiscount,
+        Boolean isActive,
+        OffsetDateTime createdAt
+    ) {
+        return new CertificateMaster(
+            certificateId,
+            certificateName,
+            issuerName,
+            rateDiscount,
+            isActive,
+            createdAt
+        );
+    }
+
+    public void updateMaster(
+        String certificateName,
+        String issuerName,
+        BigDecimal rateDiscount,
+        Boolean isActive
+    ) {
+        this.certificateName = certificateName;
+        this.issuerName = issuerName;
+        this.rateDiscount = rateDiscount;
+        this.isActive = isActive;
+    }
 }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #83 

---

### 📝 작업 내용
- 서버 실행 시 `certificate_master` 기본 데이터가 자동으로 초기화되도록 시드 로직 추가
- `certificate_id` 기준으로 기존 자격증이 없으면 insert, 있으면 기준 데이터로 update 되도록 처리
- 팀원 로컬 환경마다 OCR 인증 가능 자격증 데이터가 다르게 보이던 문제를 줄이도록 마스터 데이터 초기화 흐름 정리

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 시작 시 인증서 마스터 데이터가 자동으로 초기화됩니다.
  * 기존 인증서 기록은 자동으로 업데이트되고, 없는 경우 새로 생성됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->