### PR TITLE
[Refactor] 프론트 포트 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     build: ../bank-frontend
     container_name: nudge-bank-frontend
     ports:
-      - "81:80"
+      - "80:80"
     depends_on:
       - bank-backend
     networks:


### PR DESCRIPTION
리눅스 서버에서 기본적으로 80포트로 연결해주기 때문에 수정

## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #95 

---

### 📝 작업 내용
- docker-compose.yml에서 프론트 포트 연결을 80:80으로 수정하였습니다. 제공 받은 리눅스 서버에서 기본적으로 80포트로 연결해주기 때문에 80:80으로 수정하여야 정상 동작합니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프론트엔드 서비스의 포트 매핑을 변경하여 애플리케이션이 포트 80으로 접근 가능하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->