### PR TITLE
Feat: 대출 실행 시 대출 원금 및 상환 데이터 저장

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
@@ -54,6 +54,32 @@ public class LoanHistory {
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
 
+    public static LoanHistory create(
+        Member member,
+        Card card,
+        BigDecimal totalPrincipal,
+        String repaymentAccountNumber,
+        BigDecimal remainingPrincipal,
+        LocalDate startDate,
+        LocalDate endDate,
+        String status,
+        LocalDate expectedRepaymentDate,
+        OffsetDateTime createdAt
+    ) {
+        return LoanHistory.builder()
+            .member(member)
+            .card(card)
+            .totalPrincipal(totalPrincipal)
+            .repaymentAccountNumber(repaymentAccountNumber)
+            .remainingPrincipal(remainingPrincipal)
+            .startDate(startDate)
+            .endDate(endDate)
+            .status(status)
+            .expectedRepaymentDate(expectedRepaymentDate)
+            .createdAt(createdAt)
+            .build();
+    }
+
     public BigDecimal applyRepayment(BigDecimal repaymentAmount) {
         if (repaymentAmount == null || repaymentAmount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("상환 금액은 0보다 커야 합니다.");

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/RepaymentSchedule.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/RepaymentSchedule.java
@@ -54,4 +54,22 @@ public class RepaymentSchedule {
     @Column(name = "overdue_days")
     private Integer overdueDays;
 
+    public static RepaymentSchedule create(
+        LoanHistory loanHistory,
+        LocalDate dueDate,
+        BigDecimal plannedPrincipal,
+        BigDecimal plannedInterest
+    ) {
+        RepaymentSchedule schedule = new RepaymentSchedule();
+        schedule.loanHistory = loanHistory;
+        schedule.dueDate = dueDate;
+        schedule.plannedPrincipal = plannedPrincipal;
+        schedule.plannedInterest = plannedInterest;
+        schedule.paidPrincipal = BigDecimal.ZERO;
+        schedule.paidInterest = BigDecimal.ZERO;
+        schedule.isSettled = false;
+        schedule.overdueDays = 0;
+        return schedule;
+    }
+
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -15,16 +15,25 @@ import com.nudgebank.bankbackend.card.repository.MarketRepository;
 import com.nudgebank.bankbackend.certificate.repository.CertificateSubmissionRepository;
 import com.nudgebank.bankbackend.credit.domain.CreditHistory;
 import com.nudgebank.bankbackend.credit.repository.CreditHistoryRepository;
+import com.nudgebank.bankbackend.loan.domain.Loan;
 import com.nudgebank.bankbackend.loan.domain.LoanApplication;
+import com.nudgebank.bankbackend.loan.domain.LoanHistory;
 import com.nudgebank.bankbackend.loan.domain.LoanProduct;
+import com.nudgebank.bankbackend.loan.domain.RepaymentSchedule;
 import com.nudgebank.bankbackend.loan.dto.LoanApplicationCreateRequest;
 import com.nudgebank.bankbackend.loan.dto.LoanApplicationSummaryResponse;
 import com.nudgebank.bankbackend.loan.repository.LoanApplicationRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanHistoryRepository;
 import com.nudgebank.bankbackend.loan.repository.LoanProductRepository;
+import com.nudgebank.bankbackend.loan.repository.LoanRepository;
+import com.nudgebank.bankbackend.loan.repository.RepaymentScheduleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,6 +47,8 @@ public class LoanApplicationService {
     private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
     private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
     private static final String EMERGENCY_TYPE = "EMERGENCY";
+    private static final String ACTIVE_STATUS = "ACTIVE";
+    private static final String APPROVED_STATUS = "APPROVED";
 
     private static final String LOAN_CATEGORY_NAME = "대출";
     private static final String LOAN_MARKET_NAME = "NudgeBank 대출 실행";
@@ -45,6 +56,9 @@ public class LoanApplicationService {
 
     private final LoanApplicationRepository loanApplicationRepository;
     private final LoanProductRepository loanProductRepository;
+    private final LoanRepository loanRepository;
+    private final LoanHistoryRepository loanHistoryRepository;
+    private final RepaymentScheduleRepository repaymentScheduleRepository;
     private final CreditHistoryRepository creditHistoryRepository;
     private final MemberRepository memberRepository;
     private final CertificateSubmissionRepository certificateSubmissionRepository;
@@ -65,8 +79,7 @@ public class LoanApplicationService {
         boolean alreadyApplied = loanApplicationRepository
             .findAllByMember_MemberIdOrderByAppliedAtDesc(member.getMemberId())
             .stream()
-            .anyMatch(application ->
-                loanProductType.equals(application.getLoanProduct().getLoanProductType()));
+            .anyMatch(application -> loanProductType.equals(application.getLoanProduct().getLoanProductType()));
         if (alreadyApplied) {
             throw new IllegalArgumentException("이미 신청이 완료된 상품입니다. 내 대출 관리에서 진행 상태를 확인해 주세요.");
         }
@@ -85,7 +98,7 @@ public class LoanApplicationService {
                 .creditHistory(creditHistory)
                 .loanAmount(request.loanAmount())
                 .loanTerm(request.loanTerm())
-                .applicationStatus("APPROVED")
+                .applicationStatus(APPROVED_STATUS)
                 .appliedAt(LocalDateTime.now())
                 .reviewComment(request.purpose())
                 .monthlyIncome(request.monthlyIncome())
@@ -93,7 +106,7 @@ public class LoanApplicationService {
                 .build()
         );
 
-        createLoanDisbursement(savedApplication);
+        createLoanExecution(savedApplication);
         return toSummary(savedApplication);
     }
 
@@ -123,7 +136,7 @@ public class LoanApplicationService {
             });
     }
 
-    private void createLoanDisbursement(LoanApplication loanApplication) {
+    private void createLoanExecution(LoanApplication loanApplication) {
         Account disbursementAccount = resolveDisbursementAccount(loanApplication.getMember().getMemberId());
         Card card = cardRepository.findByAccountId(disbursementAccount.getAccountId())
             .orElseThrow(() -> new EntityNotFoundException("대출 실행에 사용할 카드가 없습니다."));
@@ -133,7 +146,48 @@ public class LoanApplicationService {
             return;
         }
 
-        disbursementAccount.deposit(loanApplication.getLoanAmount());
+        LocalDate startDate = loanApplication.getAppliedAt() != null
+            ? loanApplication.getAppliedAt().toLocalDate()
+            : LocalDate.now();
+        int repaymentMonths = resolveRepaymentMonths(loanApplication);
+        LocalDate endDate = startDate.plusMonths(repaymentMonths);
+        BigDecimal principalAmount = nullSafe(loanApplication.getLoanAmount());
+        BigDecimal interestRate = loanApplication.getLoanProduct().getMinInterestRate() != null
+            ? loanApplication.getLoanProduct().getMinInterestRate()
+            : BigDecimal.ZERO;
+
+        loanRepository.save(
+            Loan.builder()
+                .loanApplication(loanApplication)
+                .member(loanApplication.getMember())
+                .principalAmount(principalAmount)
+                .interestRate(interestRate)
+                .startDate(startDate)
+                .endDate(endDate)
+                .status(ACTIVE_STATUS)
+                .build()
+        );
+
+        LoanHistory loanHistory = loanHistoryRepository.save(
+            LoanHistory.create(
+                loanApplication.getMember(),
+                card,
+                principalAmount,
+                disbursementAccount.getAccountNumber(),
+                principalAmount,
+                startDate,
+                endDate,
+                ACTIVE_STATUS,
+                startDate.plusMonths(1),
+                OffsetDateTime.now()
+            )
+        );
+
+        repaymentScheduleRepository.saveAll(
+            buildRepaymentSchedules(loanHistory, principalAmount, interestRate, startDate, repaymentMonths)
+        );
+
+        disbursementAccount.deposit(principalAmount);
 
         MarketCategory category = resolveLoanCategory();
         Market market = resolveLoanMarket(category);
@@ -143,7 +197,7 @@ public class LoanApplicationService {
             .market(market)
             .qrId(qrId)
             .category(category)
-            .amount(loanApplication.getLoanAmount())
+            .amount(principalAmount)
             .transactionDatetime(OffsetDateTime.now())
             .menuName(loanApplication.getLoanProduct().getLoanProductName())
             .quantity(1)
@@ -170,16 +224,67 @@ public class LoanApplicationService {
 
     private synchronized MarketCategory resolveLoanCategory() {
         return marketCategoryRepository.findByCategoryName(LOAN_CATEGORY_NAME)
-            .orElseGet(() ->
-                marketCategoryRepository.save(MarketCategory.create(LOAN_CATEGORY_NAME, LOAN_CATEGORY_MCC))
-            );
+            .orElseGet(() -> marketCategoryRepository.save(MarketCategory.create(LOAN_CATEGORY_NAME, LOAN_CATEGORY_MCC)));
     }
 
     private synchronized Market resolveLoanMarket(MarketCategory category) {
         return marketRepository.findByMarketNameAndCategory_CategoryId(LOAN_MARKET_NAME, category.getCategoryId())
-            .orElseGet(() ->
-                marketRepository.save(Market.create(category, LOAN_MARKET_NAME))
+            .orElseGet(() -> marketRepository.save(Market.create(category, LOAN_MARKET_NAME)));
+    }
+
+    private List<RepaymentSchedule> buildRepaymentSchedules(
+        LoanHistory loanHistory,
+        BigDecimal principalAmount,
+        BigDecimal annualInterestRate,
+        LocalDate startDate,
+        int repaymentMonths
+    ) {
+        List<RepaymentSchedule> schedules = new ArrayList<>();
+        BigDecimal remainingPrincipal = principalAmount;
+        BigDecimal monthlyPrincipal = principalAmount
+            .divide(BigDecimal.valueOf(repaymentMonths), 2, RoundingMode.DOWN);
+        BigDecimal allocatedPrincipal = BigDecimal.ZERO;
+
+        for (int month = 1; month <= repaymentMonths; month++) {
+            BigDecimal plannedPrincipal = month == repaymentMonths
+                ? principalAmount.subtract(allocatedPrincipal)
+                : monthlyPrincipal;
+            BigDecimal plannedInterest = remainingPrincipal
+                .multiply(annualInterestRate)
+                .divide(BigDecimal.valueOf(100), 10, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(12), 2, RoundingMode.HALF_UP);
+
+            schedules.add(
+                RepaymentSchedule.create(
+                    loanHistory,
+                    startDate.plusMonths(month),
+                    plannedPrincipal,
+                    plannedInterest
+                )
             );
+
+            allocatedPrincipal = allocatedPrincipal.add(plannedPrincipal);
+            remainingPrincipal = remainingPrincipal.subtract(plannedPrincipal).max(BigDecimal.ZERO);
+        }
+
+        return schedules;
+    }
+
+    private int resolveRepaymentMonths(LoanApplication loanApplication) {
+        Integer repaymentPeriodMonth = loanApplication.getLoanProduct().getRepaymentPeriodMonth();
+        if (repaymentPeriodMonth != null && repaymentPeriodMonth > 0) {
+            return repaymentPeriodMonth;
+        }
+
+        String loanTerm = loanApplication.getLoanTerm();
+        if (loanTerm != null) {
+            String digits = loanTerm.replaceAll("[^0-9]", "");
+            if (!digits.isBlank()) {
+                return Integer.parseInt(digits);
+            }
+        }
+
+        return 12;
     }
 
     private LoanApplicationSummaryResponse toSummary(LoanApplication loanApplication) {
@@ -223,5 +328,9 @@ public class LoanApplicationService {
             case EMERGENCY_TYPE -> "situate-loan";
             default -> loanProductType;
         };
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
     }
 }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #94 

---

### 📝 작업 내용
- 대출 신청 시 `loan`, `loan_history`, `repayment_schedule` 데이터가 함께 생성되도록 저장 로직 추가
- 총 원금과 잔여 원금이 `loan_history`에 실제로 저장되도록 반영
- 내 대출 관리 화면이 fallback이 아닌 실제 대출 실행 데이터 기반으로 조회될 수 있도록 구조 보완
- 대출 실행 거래 생성 로직과 함께 대출 시작일, 만기일, 다음 납입 일정이 저장되도록 처리

---

### 📷 스크린샷 (선택)
- 
<img width="1283" height="362" alt="image" src="https://github.com/user-attachments/assets/140f7b67-e811-40ce-bc74-a6d3fbb82c24" />

- 
<img width="1288" height="161" alt="image" src="https://github.com/user-attachments/assets/c10e8a40-053d-43a1-a164-61108c34b07e" />

-
<img width="1308" height="62" alt="image" src="https://github.com/user-attachments/assets/6edbec16-be75-4272-86da-1bef8b646e0f" />



---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대출 신청 및 실행 프로세스 개선으로 더 정확한 대출 관리 기능 추가
  * 월별 상환 일정 자동 생성 및 관리 기능 강화
  * 대출 정보 추적 및 저장 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->