### PR TITLE
Feat: 자기계발 대출 신청 시 실행 및 상환 데이터 저장 구조 보완

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/loan/controller/MyLoanManagementController.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/controller/MyLoanManagementController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,29 +23,38 @@ public class MyLoanManagementController {
     private final MyLoanManagementService myLoanManagementService;
 
     @GetMapping("/summary")
-    public MyLoanSummaryResponse getSummary(Authentication authentication) {
+    public MyLoanSummaryResponse getSummary(
+        Authentication authentication,
+        @RequestParam(required = false) String productKey
+    ) {
         Long memberId = SecurityUtil.extractUserId(authentication);
         if (memberId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        return myLoanManagementService.getSummary(memberId);
+        return myLoanManagementService.getSummary(memberId, productKey);
     }
 
     @GetMapping("/repayment-schedules")
-    public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(Authentication authentication) {
+    public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(
+        Authentication authentication,
+        @RequestParam(required = false) String productKey
+    ) {
         Long memberId = SecurityUtil.extractUserId(authentication);
         if (memberId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        return myLoanManagementService.getRepaymentSchedules(memberId);
+        return myLoanManagementService.getRepaymentSchedules(memberId, productKey);
     }
 
     @GetMapping("/repayment-histories")
-    public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(Authentication authentication) {
+    public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(
+        Authentication authentication,
+        @RequestParam(required = false) String productKey
+    ) {
         Long memberId = SecurityUtil.extractUserId(authentication);
         if (memberId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
-        return myLoanManagementService.getRepaymentHistories(memberId);
+        return myLoanManagementService.getRepaymentHistories(memberId, productKey);
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanApplication.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanApplication.java
@@ -1,6 +1,7 @@
 package com.nudgebank.bankbackend.loan.domain;
 
 import com.nudgebank.bankbackend.auth.domain.Member;
+import com.nudgebank.bankbackend.card.domain.Card;
 import com.nudgebank.bankbackend.credit.domain.CreditHistory;
 import jakarta.persistence.*;
 import lombok.*;
@@ -32,6 +33,10 @@ public class LoanApplication {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "credit_history_id", nullable = false)
     private CreditHistory creditHistory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false)
+    private Card card;
 
     @Column(name = "loan_amount", precision = 15, scale = 2)
     private BigDecimal loanAmount;

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanHistory.java
@@ -26,7 +26,7 @@ public class LoanHistory {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "card_id", nullable = false)
     private Card card;
 

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationCreateRequest.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationCreateRequest.java
@@ -8,5 +8,6 @@ public record LoanApplicationCreateRequest(
     String loanTerm,
     BigDecimal monthlyIncome,
     Integer salaryDate,
-    String purpose
+    String purpose,
+    Long cardId
 ) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanApplicationRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanApplicationRepository.java
@@ -10,5 +10,10 @@ public interface LoanApplicationRepository extends JpaRepository<LoanApplication
 
     Optional<LoanApplication> findTopByMember_MemberIdOrderByAppliedAtDesc(Long memberId);
 
+    Optional<LoanApplication> findTopByMember_MemberIdAndLoanProduct_LoanProductTypeOrderByAppliedAtDesc(
+        Long memberId,
+        String loanProductType
+    );
+
     List<LoanApplication> findAllByMember_MemberIdOrderByAppliedAtDesc(Long memberId);
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
@@ -10,4 +10,11 @@ public interface LoanHistoryRepository extends JpaRepository<LoanHistory, Long> 
     Optional<LoanHistory> findByCard_CardIdAndStatus(Long cardId, String status);
 
     Optional<LoanHistory> findTopByMember_MemberIdOrderByCreatedAtDesc(Long memberId);
+
+    Optional<LoanHistory> findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateOrderByCreatedAtDesc(
+        Long memberId,
+        Long cardId,
+        java.math.BigDecimal totalPrincipal,
+        java.time.LocalDate startDate
+    );
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanHistoryRepository.java
@@ -17,4 +17,14 @@ public interface LoanHistoryRepository extends JpaRepository<LoanHistory, Long> 
         java.math.BigDecimal totalPrincipal,
         java.time.LocalDate startDate
     );
+
+    Optional<LoanHistory> findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateAndEndDateOrderByCreatedAtDesc(
+        Long memberId,
+        Long cardId,
+        java.math.BigDecimal totalPrincipal,
+        java.time.LocalDate startDate,
+        java.time.LocalDate endDate
+    );
+
+    boolean existsByRepaymentAccountNumber(String repaymentAccountNumber);
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
@@ -7,4 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LoanRepository extends JpaRepository<Loan, Long> {
 
     Optional<Loan> findTopByMember_MemberIdOrderByStartDateDescIdDesc(Long memberId);
+
+    Optional<Loan> findTopByMember_MemberIdAndLoanApplication_LoanProduct_LoanProductTypeOrderByStartDateDescIdDesc(
+        Long memberId,
+        String loanProductType
+    );
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -36,6 +36,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -218,24 +219,18 @@ public class LoanApplicationService {
     }
 
     private Card resolveSelectedCard(Long memberId, Long requestedCardId) {
-        if (requestedCardId != null) {
-            Card card = cardRepository.findById(requestedCardId)
-                .orElseThrow(() -> new EntityNotFoundException("대출 신청 카드를 찾을 수 없습니다."));
-            Account cardAccount = accountRepository.findById(card.getAccountId())
-                .orElseThrow(() -> new EntityNotFoundException("대출 신청 카드의 계좌를 찾을 수 없습니다."));
-            if (!memberId.equals(cardAccount.getMemberId())) {
-                throw new IllegalArgumentException("요청한 카드를 사용할 수 없습니다.");
-            }
-            return card;
+        if (requestedCardId == null) {
+            throw new IllegalArgumentException("대출 신청 카드를 선택해 주세요.");
         }
 
-        List<Account> accounts = accountRepository.findAllByMemberId(memberId);
-        if (accounts.isEmpty()) {
-            throw new EntityNotFoundException("대출 실행 계좌를 찾을 수 없습니다.");
+        Card card = cardRepository.findById(requestedCardId)
+            .orElseThrow(() -> new EntityNotFoundException("대출 신청 카드를 찾을 수 없습니다."));
+        Account cardAccount = accountRepository.findById(card.getAccountId())
+            .orElseThrow(() -> new EntityNotFoundException("대출 신청 카드의 계좌를 찾을 수 없습니다."));
+        if (!memberId.equals(cardAccount.getMemberId())) {
+            throw new IllegalArgumentException("요청한 카드를 사용할 수 없습니다.");
         }
-
-        return cardRepository.findByAccountId(accounts.get(0).getAccountId())
-            .orElseThrow(() -> new EntityNotFoundException("대출 실행에 사용할 카드가 없습니다."));
+        return card;
     }
 
     private synchronized MarketCategory resolveLoanCategory() {
@@ -351,8 +346,13 @@ public class LoanApplicationService {
     }
 
     private String generateVirtualAccountNumber() {
-        long first = ThreadLocalRandom.current().nextLong(1_000_000L, 10_000_000L);
-        long second = ThreadLocalRandom.current().nextLong(1_000_000L, 10_000_000L);
-        return first + "-" + second;
+        for (int attempt = 0; attempt < 5; attempt++) {
+            String candidate = "VA-" + UUID.randomUUID().toString().replace("-", "").substring(0, 16).toUpperCase();
+            if (!loanHistoryRepository.existsByRepaymentAccountNumber(candidate)) {
+                return candidate;
+            }
+        }
+
+        throw new IllegalStateException("가상계좌 번호 생성에 실패했습니다.");
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -35,6 +35,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,12 +91,15 @@ public class LoanApplicationService {
         }
 
         CreditHistory creditHistory = resolveCreditHistory(member.getMemberId(), loanProductType);
+        Card selectedCard = resolveSelectedCard(member.getMemberId(), request.cardId());
+        Account repaymentAccount = resolveDisbursementAccount(member.getMemberId(), selectedCard);
 
         LoanApplication savedApplication = loanApplicationRepository.save(
             LoanApplication.builder()
                 .loanProduct(loanProduct)
                 .member(member)
                 .creditHistory(creditHistory)
+                .card(selectedCard)
                 .loanAmount(request.loanAmount())
                 .loanTerm(request.loanTerm())
                 .applicationStatus(APPROVED_STATUS)
@@ -106,7 +110,7 @@ public class LoanApplicationService {
                 .build()
         );
 
-        createLoanExecution(savedApplication);
+        createLoanExecution(savedApplication, repaymentAccount);
         return toSummary(savedApplication);
     }
 
@@ -136,10 +140,8 @@ public class LoanApplicationService {
             });
     }
 
-    private void createLoanExecution(LoanApplication loanApplication) {
-        Account disbursementAccount = resolveDisbursementAccount(loanApplication.getMember().getMemberId());
-        Card card = cardRepository.findByAccountId(disbursementAccount.getAccountId())
-            .orElseThrow(() -> new EntityNotFoundException("대출 실행에 사용할 카드가 없습니다."));
+    private void createLoanExecution(LoanApplication loanApplication, Account repaymentAccount) {
+        Card card = loanApplication.getCard();
 
         String qrId = "loan-disbursement-" + loanApplication.getId();
         if (cardTransactionRepository.existsByQrId(qrId)) {
@@ -173,7 +175,7 @@ public class LoanApplicationService {
                 loanApplication.getMember(),
                 card,
                 principalAmount,
-                disbursementAccount.getAccountNumber(),
+                generateVirtualAccountNumber(),
                 principalAmount,
                 startDate,
                 endDate,
@@ -187,7 +189,7 @@ public class LoanApplicationService {
             buildRepaymentSchedules(loanHistory, principalAmount, interestRate, startDate, repaymentMonths)
         );
 
-        disbursementAccount.deposit(principalAmount);
+        repaymentAccount.deposit(principalAmount);
 
         MarketCategory category = resolveLoanCategory();
         Market market = resolveLoanMarket(category);
@@ -206,20 +208,34 @@ public class LoanApplicationService {
         cardTransactionRepository.save(transaction);
     }
 
-    private Account resolveDisbursementAccount(Long memberId) {
-        List<Account> accounts = accountRepository.findAllByMemberId(memberId);
+    private Account resolveDisbursementAccount(Long memberId, Card selectedCard) {
+        Account account = accountRepository.findByIdForUpdate(selectedCard.getAccountId())
+            .orElseThrow(() -> new EntityNotFoundException("대출 실행 계좌를 찾을 수 없습니다."));
+        if (!memberId.equals(account.getMemberId())) {
+            throw new IllegalArgumentException("요청한 카드의 계좌를 사용할 수 없습니다.");
+        }
+        return account;
+    }
 
+    private Card resolveSelectedCard(Long memberId, Long requestedCardId) {
+        if (requestedCardId != null) {
+            Card card = cardRepository.findById(requestedCardId)
+                .orElseThrow(() -> new EntityNotFoundException("대출 신청 카드를 찾을 수 없습니다."));
+            Account cardAccount = accountRepository.findById(card.getAccountId())
+                .orElseThrow(() -> new EntityNotFoundException("대출 신청 카드의 계좌를 찾을 수 없습니다."));
+            if (!memberId.equals(cardAccount.getMemberId())) {
+                throw new IllegalArgumentException("요청한 카드를 사용할 수 없습니다.");
+            }
+            return card;
+        }
+
+        List<Account> accounts = accountRepository.findAllByMemberId(memberId);
         if (accounts.isEmpty()) {
             throw new EntityNotFoundException("대출 실행 계좌를 찾을 수 없습니다.");
         }
 
-        if (accounts.size() > 1) {
-            throw new IllegalArgumentException("입금 대상 계좌가 여러 개입니다. 대출 실행 계좌를 명시해 주세요.");
-        }
-
-        Long accountId = accounts.get(0).getAccountId();
-        return accountRepository.findByIdForUpdate(accountId)
-            .orElseThrow(() -> new EntityNotFoundException("대출 실행 계좌를 찾을 수 없습니다."));
+        return cardRepository.findByAccountId(accounts.get(0).getAccountId())
+            .orElseThrow(() -> new EntityNotFoundException("대출 실행에 사용할 카드가 없습니다."));
     }
 
     private synchronized MarketCategory resolveLoanCategory() {
@@ -332,5 +348,11 @@ public class LoanApplicationService {
 
     private BigDecimal nullSafe(BigDecimal value) {
         return value != null ? value : BigDecimal.ZERO;
+    }
+
+    private String generateVirtualAccountNumber() {
+        long first = ThreadLocalRandom.current().nextLong(1_000_000L, 10_000_000L);
+        long second = ThreadLocalRandom.current().nextLong(1_000_000L, 10_000_000L);
+        return first + "-" + second;
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -177,22 +177,23 @@ public class MyLoanManagementService {
     }
 
     private java.util.Optional<LoanHistory> resolveLoanHistory(Long memberId, String productKey) {
+        Loan loan = resolveLoan(memberId, productKey).orElse(null);
+        if (loan != null && loan.getLoanApplication() != null && loan.getLoanApplication().getCard() != null) {
+            return loanHistoryRepository
+                .findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateAndEndDateOrderByCreatedAtDesc(
+                    memberId,
+                    loan.getLoanApplication().getCard().getCardId(),
+                    nullSafe(loan.getPrincipalAmount()),
+                    loan.getStartDate(),
+                    loan.getEndDate()
+                );
+        }
+
         if (productKey == null || productKey.isBlank()) {
             return loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId);
         }
 
-        Loan loan = resolveLoan(memberId, productKey).orElse(null);
-        if (loan == null || loan.getLoanApplication() == null || loan.getLoanApplication().getCard() == null) {
-            return java.util.Optional.empty();
-        }
-
-        return loanHistoryRepository
-            .findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateOrderByCreatedAtDesc(
-                memberId,
-                loan.getLoanApplication().getCard().getCardId(),
-                nullSafe(loan.getPrincipalAmount()),
-                loan.getStartDate()
-            );
+        return java.util.Optional.empty();
     }
 
     private String toLoanProductType(String productKey) {
@@ -204,7 +205,7 @@ public class MyLoanManagementService {
             case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
             case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
             case "situate-loan" -> EMERGENCY_TYPE;
-            default -> null;
+            default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
         };
     }
 

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -23,19 +23,23 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class MyLoanManagementService {
 
+    private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
+    private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
+    private static final String EMERGENCY_TYPE = "EMERGENCY";
+
     private final LoanApplicationRepository loanApplicationRepository;
     private final LoanHistoryRepository loanHistoryRepository;
     private final LoanRepository loanRepository;
     private final RepaymentScheduleRepository repaymentScheduleRepository;
     private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
 
-    public MyLoanSummaryResponse getSummary(Long memberId) {
-        LoanHistory loanHistory = loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId).orElse(null);
+    public MyLoanSummaryResponse getSummary(Long memberId, String productKey) {
+        LoanHistory loanHistory = resolveLoanHistory(memberId, productKey).orElse(null);
         if (loanHistory == null) {
-            return buildPendingLoanSummary(memberId);
+            return buildPendingLoanSummary(memberId, productKey);
         }
 
-        Loan loan = loanRepository.findTopByMember_MemberIdOrderByStartDateDescIdDesc(memberId).orElse(null);
+        Loan loan = resolveLoan(memberId, productKey).orElse(null);
         List<RepaymentSchedule> schedules =
             repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId());
 
@@ -70,10 +74,10 @@ public class MyLoanManagementService {
         );
     }
 
-    public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(Long memberId) {
-        LoanHistory loanHistory = loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId).orElse(null);
+    public List<MyLoanRepaymentScheduleResponse> getRepaymentSchedules(Long memberId, String productKey) {
+        LoanHistory loanHistory = resolveLoanHistory(memberId, productKey).orElse(null);
         if (loanHistory == null) {
-            ensureDisplayableLoanExists(memberId);
+            ensureDisplayableLoanExists(memberId, productKey);
             return List.of();
         }
 
@@ -91,10 +95,10 @@ public class MyLoanManagementService {
             .toList();
     }
 
-    public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(Long memberId) {
-        LoanHistory loanHistory = loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId).orElse(null);
+    public List<MyLoanRepaymentHistoryResponse> getRepaymentHistories(Long memberId, String productKey) {
+        LoanHistory loanHistory = resolveLoanHistory(memberId, productKey).orElse(null);
         if (loanHistory == null) {
-            ensureDisplayableLoanExists(memberId);
+            ensureDisplayableLoanExists(memberId, productKey);
             return List.of();
         }
 
@@ -110,8 +114,8 @@ public class MyLoanManagementService {
             .toList();
     }
 
-    private MyLoanSummaryResponse buildPendingLoanSummary(Long memberId) {
-        LoanApplication application = ensureDisplayableLoanExists(memberId);
+    private MyLoanSummaryResponse buildPendingLoanSummary(Long memberId, String productKey) {
+        LoanApplication application = ensureDisplayableLoanExists(memberId, productKey);
         BigDecimal totalPrincipal = nullSafe(application.getLoanAmount());
         BigDecimal interestRate = application.getLoanProduct().getMinInterestRate() != null
             ? application.getLoanProduct().getMinInterestRate()
@@ -143,14 +147,65 @@ public class MyLoanManagementService {
         );
     }
 
-    private LoanApplication ensureDisplayableLoanExists(Long memberId) {
-        return loanApplicationRepository.findTopByMember_MemberIdOrderByAppliedAtDesc(memberId)
+    private LoanApplication ensureDisplayableLoanExists(Long memberId, String productKey) {
+        String loanProductType = toLoanProductType(productKey);
+        return (loanProductType == null
+            ? loanApplicationRepository.findTopByMember_MemberIdOrderByAppliedAtDesc(memberId)
+            : loanApplicationRepository.findTopByMember_MemberIdAndLoanProduct_LoanProductTypeOrderByAppliedAtDesc(
+                memberId,
+                loanProductType
+            ))
             .orElseThrow(() -> new EntityNotFoundException("대출 상품이 없습니다."));
     }
 
     private LoanHistory getLatestLoanHistory(Long memberId) {
         return loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId)
             .orElseThrow(() -> new EntityNotFoundException("대출 관리 정보가 없습니다."));
+    }
+
+    private java.util.Optional<Loan> resolveLoan(Long memberId, String productKey) {
+        String loanProductType = toLoanProductType(productKey);
+        if (loanProductType == null) {
+            return loanRepository.findTopByMember_MemberIdOrderByStartDateDescIdDesc(memberId);
+        }
+
+        return loanRepository
+            .findTopByMember_MemberIdAndLoanApplication_LoanProduct_LoanProductTypeOrderByStartDateDescIdDesc(
+                memberId,
+                loanProductType
+            );
+    }
+
+    private java.util.Optional<LoanHistory> resolveLoanHistory(Long memberId, String productKey) {
+        if (productKey == null || productKey.isBlank()) {
+            return loanHistoryRepository.findTopByMember_MemberIdOrderByCreatedAtDesc(memberId);
+        }
+
+        Loan loan = resolveLoan(memberId, productKey).orElse(null);
+        if (loan == null || loan.getLoanApplication() == null || loan.getLoanApplication().getCard() == null) {
+            return java.util.Optional.empty();
+        }
+
+        return loanHistoryRepository
+            .findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateOrderByCreatedAtDesc(
+                memberId,
+                loan.getLoanApplication().getCard().getCardId(),
+                nullSafe(loan.getPrincipalAmount()),
+                loan.getStartDate()
+            );
+    }
+
+    private String toLoanProductType(String productKey) {
+        if (productKey == null || productKey.isBlank()) {
+            return null;
+        }
+
+        return switch (productKey) {
+            case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
+            case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
+            case "situate-loan" -> EMERGENCY_TYPE;
+            default -> null;
+        };
     }
 
     private BigDecimal nullSafe(BigDecimal value) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #102 

---

### 📝 작업 내용

- 대출 신청 시 선택한 카드 정보를 함께 저장하고, 해당 카드에 연결된 계좌를 기준으로 대출 실행 데이터가 생성되도록 보완
- `loan_history`의 카드 연관 구조를 조정해 서로 다른 대출상품이 같은 카드 기준으로도 생성될 수 있도록 수정
- 대출 관리 조회 API에서 `productKey` 기준 상품별 요약/상환 일정/상환 이력을 조회할 수 있도록 지원

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대출 상품별(productKey)로 대출 요약·상환 스케줄·상환 내역 조회 가능
  * 대출 신청 시 카드 선택 기능 추가

* **개선 사항**
  * 가상 계좌 번호 자동 생성으로 대출 입금/상환 처리 간편화
  * 상품별 조회 시 전제 미충족 시 빈 목록 반환으로 오류 감소 및 UX 개선
  * 대출 조회·필터링 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->