### PR TITLE
Feat: 소비분석대출 보호잔액 저장 로직 추가

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
+++ b/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.OffsetDateTime;
 
 @Entity
@@ -119,6 +120,14 @@ public class Account {
       throw new IllegalArgumentException("보호잔액은 계좌 잔액보다 클 수 없습니다.");
     }
 
-    this.protectedBalance = protectedBalance;
+    this.protectedBalance = normalizeProtectedBalanceScale(protectedBalance);
+  }
+
+  private BigDecimal normalizeProtectedBalanceScale(BigDecimal protectedBalance) {
+    try {
+      return protectedBalance.setScale(2, RoundingMode.UNNECESSARY);
+    } catch (ArithmeticException exception) {
+      throw new IllegalArgumentException("보호잔액은 소수점 둘째 자리까지만 입력할 수 있습니다.");
+    }
   }
 }

--- a/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
+++ b/src/main/java/com/nudgebank/bankbackend/account/domain/Account.java
@@ -101,4 +101,24 @@ public class Account {
 
     this.balance = this.balance.add(amount);
   }
+
+  public void updateProtectedBalance(BigDecimal protectedBalance) {
+    if (protectedBalance == null) {
+      throw new IllegalArgumentException("보호잔액은 필수입니다.");
+    }
+
+    if (protectedBalance.compareTo(BigDecimal.ZERO) < 0) {
+      throw new IllegalArgumentException("보호잔액은 0 이상이어야 합니다.");
+    }
+
+    if (this.balance == null) {
+      throw new IllegalStateException("계좌 잔액 정보가 없습니다.");
+    }
+
+    if (protectedBalance.compareTo(this.balance) > 0) {
+      throw new IllegalArgumentException("보호잔액은 계좌 잔액보다 클 수 없습니다.");
+    }
+
+    this.protectedBalance = protectedBalance;
+  }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanApplication.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/domain/LoanApplication.java
@@ -56,6 +56,9 @@ public class LoanApplication {
     @Column(name = "monthly_income", precision = 15, scale = 2)
     private BigDecimal monthlyIncome;
 
+    @Column(name = "protected_balance", precision = 15, scale = 2)
+    private BigDecimal protectedBalance;
+
     @Column(name = "salary_date")
     private Integer salaryDate;
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationCreateRequest.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanApplicationCreateRequest.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 public record LoanApplicationCreateRequest(
     String productKey,
     BigDecimal loanAmount,
+    BigDecimal protectedBalance,
     String loanTerm,
     BigDecimal monthlyIncome,
     Integer salaryDate,

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -94,6 +94,11 @@ public class LoanApplicationService {
         CreditHistory creditHistory = resolveCreditHistory(member.getMemberId(), loanProductType);
         Card selectedCard = resolveSelectedCard(member.getMemberId(), request.cardId());
         Account repaymentAccount = resolveDisbursementAccount(member.getMemberId(), selectedCard);
+        BigDecimal protectedBalance = validateProtectedBalance(
+            loanProductType,
+            request.protectedBalance(),
+            request.loanAmount()
+        );
 
         LoanApplication savedApplication = loanApplicationRepository.save(
             LoanApplication.builder()
@@ -107,6 +112,7 @@ public class LoanApplicationService {
                 .appliedAt(LocalDateTime.now())
                 .reviewComment(request.purpose())
                 .monthlyIncome(request.monthlyIncome())
+                .protectedBalance(protectedBalance)
                 .salaryDate(request.salaryDate())
                 .build()
         );
@@ -196,6 +202,7 @@ public class LoanApplicationService {
         );
 
         repaymentAccount.deposit(principalAmount);
+        repaymentAccount.updateProtectedBalance(resolveProtectedBalanceForExecution(loanApplication, repaymentAccount));
 
         MarketCategory category = resolveLoanCategory();
         Market market = resolveLoanMarket(category);
@@ -385,5 +392,41 @@ public class LoanApplicationService {
         }
 
         throw new IllegalStateException("가상계좌 번호 생성에 실패했습니다.");
+    }
+
+    private BigDecimal validateProtectedBalance(String loanProductType, BigDecimal protectedBalance, BigDecimal loanAmount) {
+        if (!CONSUMPTION_ANALYSIS_TYPE.equals(loanProductType)) {
+            return BigDecimal.ZERO;
+        }
+
+        if (protectedBalance == null) {
+            throw new IllegalArgumentException("보호잔액을 입력해 주세요.");
+        }
+
+        if (protectedBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("보호잔액은 0 이상이어야 합니다.");
+        }
+
+        BigDecimal sanitizedLoanAmount = nullSafe(loanAmount);
+        if (sanitizedLoanAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("대출 신청 금액을 확인해 주세요.");
+        }
+
+        if (protectedBalance.compareTo(sanitizedLoanAmount) > 0) {
+            throw new IllegalArgumentException("보호잔액은 신청 금액보다 클 수 없습니다.");
+        }
+
+        return protectedBalance;
+    }
+
+    private BigDecimal resolveProtectedBalanceForExecution(LoanApplication loanApplication, Account repaymentAccount) {
+        BigDecimal protectedBalance = nullSafe(loanApplication.getProtectedBalance());
+        BigDecimal currentBalance = nullSafe(repaymentAccount.getBalance());
+
+        if (protectedBalance.compareTo(currentBalance) > 0) {
+            throw new IllegalStateException("보호잔액이 대출 실행 후 계좌 잔액을 초과합니다.");
+        }
+
+        return protectedBalance;
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -416,7 +416,15 @@ public class LoanApplicationService {
             throw new IllegalArgumentException("보호잔액은 신청 금액보다 클 수 없습니다.");
         }
 
-        return protectedBalance;
+        return normalizeProtectedBalanceScale(protectedBalance);
+    }
+
+    private BigDecimal normalizeProtectedBalanceScale(BigDecimal protectedBalance) {
+        try {
+            return protectedBalance.setScale(2, RoundingMode.UNNECESSARY);
+        } catch (ArithmeticException exception) {
+            throw new IllegalArgumentException("보호잔액은 소수점 둘째 자리까지만 입력할 수 있습니다.");
+        }
     }
 
     private BigDecimal resolveProtectedBalanceForExecution(LoanApplication loanApplication, Account repaymentAccount) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #109 

---

### 📝 작업 내용
- 소비분석대출 신청 시 입력한 보호잔액을 저장하고 이후에 재무상태 계산에 반영할 수 있도록 로직을 추가

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계좌의 보호 잔액을 업데이트하고 계정에 안전하게 고정할 수 있는 기능 추가
  * 대출 신청 시 보호 잔액을 입력·저장할 수 있도록 지원
  * 대출 생성 및 실행 시 보호 잔액의 유효성(비음수·잔액 초과 방지·소수점 정밀도) 검증 및 자동 적용 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->