### PR TITLE
Feat: 신용점수 기반 대출 가능 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/loan/controller/LoanProductController.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/controller/LoanProductController.java
@@ -1,12 +1,19 @@
 package com.nudgebank.bankbackend.loan.controller;
 
+import com.nudgebank.bankbackend.auth.security.SecurityUtil;
+import com.nudgebank.bankbackend.loan.dto.LoanEligibilityRequest;
+import com.nudgebank.bankbackend.loan.dto.LoanEligibilityResponse;
 import com.nudgebank.bankbackend.loan.dto.LoanProductDetailResponse;
 import com.nudgebank.bankbackend.loan.dto.LoanProductListResponse;
+import com.nudgebank.bankbackend.loan.service.LoanEligibilityService;
 import com.nudgebank.bankbackend.loan.service.LoanProductService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/loan-products")
@@ -14,6 +21,7 @@ import java.util.List;
 public class LoanProductController {
 
     private final LoanProductService loanProductService;
+    private final LoanEligibilityService loanEligibilityService;
 
     // 대출 상품 목록 조회
     @GetMapping
@@ -27,4 +35,16 @@ public class LoanProductController {
         return loanProductService.getLoanProductDetail(loanProductId);
     }
 
+    // 신용점수 기반 대출 가능 여부 조회
+    @PostMapping("/eligibility")
+    public LoanEligibilityResponse checkEligibility(
+            @RequestBody LoanEligibilityRequest request,
+            Authentication authentication
+    ) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return loanEligibilityService.check(memberId, request);
+    }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanEligibilityRequest.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanEligibilityRequest.java
@@ -1,0 +1,5 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+public record LoanEligibilityRequest(
+        String productKey
+) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanEligibilityResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanEligibilityResponse.java
@@ -1,14 +1,15 @@
 package com.nudgebank.bankbackend.loan.dto;
 
-import java.math.BigDecimal;
 import java.util.List;
 
+/**
+ * 내부 신용점수와 상품 조건을 기준으로 산정한
+ * 대출 가능 여부 조회 응답 DTO.
+ */
 public record LoanEligibilityResponse(
-        boolean eligible,
-        String decision,
-        Integer creditScore,
-        Long estimatedLimit,
-        String productKey,
-        BigDecimal requestedAmount,
-        List<String> reasons
+        boolean eligible,          // 최종 대출 가능 여부: true/false
+        String decision,           // 내부 판단 결과: APPROVED / REJECTED
+        Integer creditScore,       // 조회 시점의 최신 내부 신용점수
+        String productKey,         // 조회 대상 상품 키: youth-loan, consumption-loan, situate-loan
+        List<String> reasons       // 가능/불가 판단 사유 목록
 ) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanEligibilityService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanEligibilityService.java
@@ -1,0 +1,76 @@
+package com.nudgebank.bankbackend.loan.service;
+
+import com.nudgebank.bankbackend.credit.domain.CreditHistory;
+import com.nudgebank.bankbackend.credit.repository.CreditHistoryRepository;
+import com.nudgebank.bankbackend.loan.domain.LoanProduct;
+import com.nudgebank.bankbackend.loan.dto.LoanEligibilityRequest;
+import com.nudgebank.bankbackend.loan.dto.LoanEligibilityResponse;
+import com.nudgebank.bankbackend.loan.repository.LoanProductRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoanEligibilityService {
+
+    private static final int MIN_ELIGIBLE_CREDIT_SCORE = 500;
+    private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
+    private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
+    private static final String EMERGENCY_TYPE = "EMERGENCY";
+
+    private final CreditHistoryRepository creditHistoryRepository;
+    private final LoanProductRepository loanProductRepository;
+
+    public LoanEligibilityResponse check(Long memberId, LoanEligibilityRequest request) {
+        if (memberId == null) {
+            throw new IllegalArgumentException("UNAUTHORIZED");
+        }
+        if (request == null || request.productKey() == null || request.productKey().isBlank()) {
+            throw new IllegalArgumentException("INVALID_PRODUCT_KEY");
+        }
+
+        String loanProductType = toLoanProductType(request.productKey());
+        LoanProduct product = loanProductRepository.findByLoanProductType(loanProductType)
+                .orElseThrow(() -> new EntityNotFoundException("대출 상품을 찾을 수 없습니다. type=" + loanProductType));
+
+        CreditHistory creditHistory = creditHistoryRepository
+                .findTopByMemberIdOrderByEvaluatedAtDescCreditHistoryIdDesc(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("대출 가능 여부 판단을 위한 신용 정보가 없습니다."));
+
+        int creditScore = creditHistory.getCreditScore() != null ? creditHistory.getCreditScore() : 0;
+
+        List<String> reasons = new ArrayList<>();
+        boolean eligible = true;
+
+        if (creditScore < MIN_ELIGIBLE_CREDIT_SCORE) {
+            eligible = false;
+            reasons.add("신용점수가 내부 기준 500점 미만입니다.");
+        } else {
+            reasons.add("신용점수가 내부 기준 이상입니다.");
+        }
+
+        Long maxLimitAmount = product.getMaxLimitAmount() != null ? product.getMaxLimitAmount() : 0L;
+
+        return new LoanEligibilityResponse(
+                eligible,
+                eligible ? "APPROVED" : "REJECTED",
+                creditScore,
+                request.productKey(),
+                reasons
+        );
+    }
+
+    private String toLoanProductType(String productKey) {
+        return switch (productKey) {
+            case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
+            case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
+            case "situate-loan" -> EMERGENCY_TYPE;
+            default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
+        };
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #112 

---

### 📝 작업 내용
- 내부 신용점수 기반으로 대출 가능 여부 판단함
- 대출 가능 여부는 따로 DB에 저장하지 않음
- 대출 신청 전에 확인할 수 있도록 연결할 예정
- 챗봇에서도 아래와 같이 연결할 예정

> ### eligible=true
> 현재 내부 신용점수는 {creditScore}점입니다. 대출 가능 기준인 500점 이상이어서 신청 가능합니다.
> ### eligible=false
> 현재 내부 신용점수는 {creditScore}점입니다. 대출 가능 기준인 500점 미만이라 지금은 신청이 어렵습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 대출 상품 적격성 확인 기능 추가: 회원이 대출 상품 신청 시 신용점수 기반의 적격성 평가를 통해 승인 여부 및 판정 결과를 즉시 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->