### PR TITLE
[Fix] 대출 상환 이력 테이블 값 저장 문제 해결

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentExecutionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentExecutionService.java
@@ -101,7 +101,7 @@ public class AutoRepaymentExecutionService {
             return;
         }
 
-        RepaymentService.RepaymentResult result = repaymentService.repay(resolvedLoan.loanHistory(), resolvedLoan.loan(), repaymentAmount);
+        RepaymentService.RepaymentResult result = repaymentService.repay(resolvedLoan.loanHistory(), resolvedLoan.loan(), repaymentAmount, transaction);
         log.info("실제 자동 상환 금액 : " + result.totalPaid());
         if (result.totalPaid().compareTo(BigDecimal.ZERO) > 0) {
             log.info("차감할게요 : " + result.totalPaid());

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/RepaymentService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/RepaymentService.java
@@ -48,9 +48,9 @@ public class RepaymentService {
         return result;
     }
 
-    public RepaymentResult repay(LoanHistory loanHistory, Loan loan, BigDecimal requestedAmount) {
+    public RepaymentResult repay(LoanHistory loanHistory, Loan loan, BigDecimal requestedAmount, CardTransaction transaction) {
         RepaymentResult result = applyRepayment(loanHistory, loan, requestedAmount);
-        saveRepaymentHistoryIfApplied(loanHistory, null, null, result);
+        saveRepaymentHistoryIfApplied(loanHistory, transaction, null, result);
         return result;
     }
 
@@ -165,11 +165,13 @@ public class RepaymentService {
             return;
         }
 
+        repaymentRate = result.totalPaid().divide(transaction.getAmount(), 4, RoundingMode.HALF_UP);
+
         loanRepaymentHistoryRepository.save(LoanRepaymentHistory.create(
                 loanHistory,
                 transaction,
                 won(result.totalPaid()),
-                nullSafe(repaymentRate),
+                repaymentRate,
                 OffsetDateTime.now(),
                 won(result.remainingPrincipal())
         ));


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #135 

---

### 📝 작업 내용
- 자동상환 시 대출 상환 이력 테이블에 transaction_id와 repayment_rate가 적절히 저장되도록 수정하였습니다.
- 브랜치 번호를 잘못 적었습니다. 102번 이슈가 아닌 135번 이슈 관련 내용입니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 자동 상환 처리 시 거래 정보와 상환 이력의 정확한 연계가 강화되었습니다.
  * 거래 데이터를 기반으로 상환율이 자동으로 계산되어 상환 기록에 더 정확하게 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->