### PR TITLE
Feat: 자기계발 대출 OCR 날짜 및 검증 보완

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateSubmissionService.java
@@ -4,6 +4,7 @@ import com.nudgebank.bankbackend.auth.domain.Member;
 import com.nudgebank.bankbackend.auth.repository.MemberRepository;
 import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
 import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
+import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.dto.CertificateSubmissionResponse;
 import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
@@ -20,14 +21,14 @@ import com.nudgebank.bankbackend.loan.repository.RepaymentScheduleRepository;
 import com.nudgebank.bankbackend.ocr.client.OcrClient;
 import com.nudgebank.bankbackend.ocr.dto.OcrExtractResponse;
 import com.nudgebank.bankbackend.ocr.exception.InvalidCertificateUploadException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.OffsetDateTime;
-import java.util.List;
 
 @Service
 public class CertificateSubmissionService {
@@ -75,15 +76,21 @@ public class CertificateSubmissionService {
         validateRequest(memberId, loanApplicationId, certificateId, file);
         validateDuplicateVerifiedCertificate(memberId, certificateId);
 
+        LoanApplication loanApplication = loanApplicationRepository.findByIdAndMember_MemberId(loanApplicationId, memberId)
+                .orElseThrow(() -> new InvalidCertificateUploadException("\uB300\uCD9C \uC2E0\uCCAD \uC815\uBCF4\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4."));
+
         OcrExtractResponse ocrResponse = ocrClient.extract(file);
         OffsetDateTime submittedAt = OffsetDateTime.now();
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new InvalidCertificateUploadException("Member not found"));
+                .orElseThrow(() -> new InvalidCertificateUploadException("\uD68C\uC6D0 \uC815\uBCF4\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4."));
+
         CertificateMatchResult matchResult = certificateVerificationService.verify(
                 certificateId,
                 ocrResponse.extractedText(),
                 member
         );
+        LocalDate certificateDate = certificateVerificationService.extractCertificateDate(ocrResponse.extractedText());
+        matchResult = applyCertificateDateValidation(matchResult, loanApplication, certificateDate);
 
         CertificateSubmission submission = CertificateSubmission.builder()
                 .memberId(memberId)
@@ -97,7 +104,7 @@ public class CertificateSubmissionService {
                 .build();
 
         CertificateSubmission savedSubmission = certificateSubmissionRepository.save(submission);
-        if ("VERIFIED".equals(matchResult.verificationStatus().name())) {
+        if (CertificateVerificationStatus.VERIFIED.equals(matchResult.verificationStatus())) {
             applyPreferentialRate(loanApplicationId);
         }
 
@@ -121,18 +128,55 @@ public class CertificateSubmissionService {
             MultipartFile file
     ) {
         if (memberId == null || loanApplicationId == null || certificateId == null) {
-            throw new InvalidCertificateUploadException("memberId, loanApplicationId, certificateId are required");
+            throw new InvalidCertificateUploadException("memberId, loanApplicationId, certificateId\uB294 \uD544\uC218\uC785\uB2C8\uB2E4.");
         }
 
         if (file == null || file.isEmpty()) {
-            throw new InvalidCertificateUploadException("Certificate file is required");
+            throw new InvalidCertificateUploadException("\uC790\uACA9\uC99D \uD30C\uC77C\uC744 \uCCA8\uBD80\uD574 \uC8FC\uC138\uC694.");
         }
 
         LoanApplication loanApplication = loanApplicationRepository.findByIdAndMember_MemberId(loanApplicationId, memberId)
-            .orElseThrow(() -> new InvalidCertificateUploadException("대출 신청 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new InvalidCertificateUploadException("\uB300\uCD9C \uC2E0\uCCAD \uC815\uBCF4\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4."));
         if (!SELF_DEVELOPMENT_TYPE.equals(loanApplication.getLoanProduct().getLoanProductType())) {
-            throw new InvalidCertificateUploadException("자기계발 대출에만 자격증 우대금리를 적용할 수 있습니다.");
+            throw new InvalidCertificateUploadException("\uC790\uAE30\uACC4\uBC1C \uB300\uCD9C \uC2E0\uCCAD \uAC74\uC5D0\uC11C\uB9CC \uC790\uACA9\uC99D \uC778\uC99D\uC774 \uAC00\uB2A5\uD569\uB2C8\uB2E4.");
         }
+    }
+
+    private CertificateMatchResult applyCertificateDateValidation(
+            CertificateMatchResult matchResult,
+            LoanApplication loanApplication,
+            LocalDate certificateDate
+    ) {
+        if (!CertificateVerificationStatus.VERIFIED.equals(matchResult.verificationStatus())) {
+            return matchResult;
+        }
+
+        if (loanApplication.getAppliedAt() == null) {
+            return new CertificateMatchResult(
+                    CertificateVerificationStatus.VERIFICATION_FAILED,
+                    null,
+                    "LOAN_APPLICATION_DATE_NOT_FOUND"
+            );
+        }
+
+        if (certificateDate == null) {
+            return new CertificateMatchResult(
+                    CertificateVerificationStatus.VERIFICATION_FAILED,
+                    null,
+                    "CERTIFICATE_DATE_NOT_FOUND"
+            );
+        }
+
+        LocalDate applicationDate = loanApplication.getAppliedAt().toLocalDate();
+        if (certificateDate.isBefore(applicationDate)) {
+            return new CertificateMatchResult(
+                    CertificateVerificationStatus.VERIFICATION_FAILED,
+                    null,
+                    "CERTIFICATE_DATE_BEFORE_APPLICATION"
+            );
+        }
+
+        return matchResult;
     }
 
     private void validateDuplicateVerifiedCertificate(Long memberId, Long certificateId) {
@@ -144,15 +188,15 @@ public class CertificateSubmissionService {
                 );
 
         if (alreadyVerified) {
-            throw new IllegalArgumentException("이미 인증 완료된 자격증입니다.");
+            throw new IllegalArgumentException("\uC774\uBBF8 \uC778\uC99D \uC644\uB8CC\uB41C \uC790\uACA9\uC99D\uC785\uB2C8\uB2E4.");
         }
     }
 
     private void applyPreferentialRate(Long loanApplicationId) {
         LoanApplication loanApplication = loanApplicationRepository.findById(loanApplicationId)
-                .orElseThrow(() -> new InvalidCertificateUploadException("대출 신청 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new InvalidCertificateUploadException("\uB300\uCD9C \uC2E0\uCCAD \uC815\uBCF4\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4."));
         Loan loan = loanRepository.findTopByLoanApplication_IdOrderByIdDesc(loanApplicationId)
-                .orElseThrow(() -> new InvalidCertificateUploadException("대출 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new InvalidCertificateUploadException("\uB300\uCD9C \uC815\uBCF4\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4."));
 
         LoanHistory loanHistory = loanHistoryRepository
                 .findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateAndEndDateOrderByCreatedAtDesc(
@@ -162,13 +206,13 @@ public class CertificateSubmissionService {
                         loan.getStartDate(),
                         loan.getEndDate()
                 )
-                .orElseThrow(() -> new InvalidCertificateUploadException("대출 이력을 찾을 수 없습니다."));
+                .orElseThrow(() -> new InvalidCertificateUploadException("\uB300\uCD9C \uC774\uB825\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4."));
 
         BigDecimal totalDiscount = certificateSubmissionRepository
                 .findAllByLoanApplicationIdAndVerificationStatus(loanApplicationId, "VERIFIED")
                 .stream()
                 .map(CertificateSubmission::getCertificateId)
-                .map(certificateId -> certificateMasterRepository.findByCertificateIdAndIsActiveTrue(certificateId)
+                .map(id -> certificateMasterRepository.findByCertificateIdAndIsActiveTrue(id)
                         .map(CertificateMaster::getRateDiscount)
                         .orElse(BigDecimal.ZERO))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -211,8 +255,9 @@ public class CertificateSubmissionService {
         BigDecimal rate = baseRate ? loanProduct.getMaxInterestRate() : loanProduct.getMinInterestRate();
         if (rate == null) {
             throw new IllegalStateException(
-                baseRate ? "대출 상품 기준 금리가 설정되지 않았습니다."
-                    : "대출 상품 최저 금리가 설정되지 않았습니다."
+                    baseRate
+                            ? "\uAE30\uC900 \uAE08\uB9AC\uAC00 \uC124\uC815\uB418\uC5B4 \uC788\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4."
+                            : "\uCD5C\uC800 \uAE08\uB9AC\uAC00 \uC124\uC815\uB418\uC5B4 \uC788\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4."
             );
         }
         return rate;

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -2,40 +2,94 @@ package com.nudgebank.bankbackend.certificate.service;
 
 import com.nudgebank.bankbackend.auth.domain.Member;
 import com.nudgebank.bankbackend.certificate.domain.CertificateMaster;
+import com.nudgebank.bankbackend.certificate.domain.CertificateIssuerAlias;
 import com.nudgebank.bankbackend.certificate.domain.CertificateVerificationStatus;
 import com.nudgebank.bankbackend.certificate.dto.CertificateMatchResult;
 import com.nudgebank.bankbackend.certificate.exception.CertificateVerificationException;
+import com.nudgebank.bankbackend.certificate.repository.CertificateIssuerAliasRepository;
 import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
-import org.springframework.stereotype.Service;
-
 import java.text.Normalizer;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
 
 @Service
 public class CertificateVerificationService {
 
-    private static final Pattern NAME_PATTERN = Pattern.compile(
-            "(?:성\\s*명|이\\s*름)\\s*[:：`\"' ]*\\s*([가-힣]{2,10})"
-    );
-    private static final String[] PASS_KEYWORDS = {
-            "합격", "합격증", "합격증명서", "취득", "증명", "확인", "확인서"
+    private static final Pattern NAME_PATTERN =
+            Pattern.compile("(?:\\uC131\\uBA85|\\uC774\\uB984)\\s*[:\\uFF1A]?\\s*([\\uAC00-\\uD7A3]{2,10})");
+
+    private static final Pattern[] DATE_PATTERNS = {
+            Pattern.compile("(20\\d{2})[./-](\\d{1,2})[./-](\\d{1,2})"),
+            Pattern.compile("(20\\d{2})\\s*\\uB144\\s*(\\d{1,2})\\s*\\uC6D4\\s*(\\d{1,2})\\s*\\uC77C")
     };
+
+    private static final Pattern LABELED_DATE_PATTERN = Pattern.compile(
+            "(\\uCDE8\\uB4DD\\uC77C|\\uCDE8\\uB4DD\\uC77C\\uC790|\\uD569\\uACA9\\uC77C|\\uD569\\uACA9\\uC77C\\uC790|\\uD569\\uACA9\\uC5F0\\uC6D4\\uC77C|\\uBC1C\\uAE09\\uC77C|\\uBC1C\\uAE09\\uC5F0\\uC6D4\\uC77C|\\uC790\\uACA9\\uCDE8\\uB4DD\\uC77C|\\uC790\\uACA9\\uC99D\\uCDE8\\uB4DD\\uC77C|\\uC790\\uACA9\\uC744\\uCDE8\\uB4DD).{0,30}?(20\\d{2})\\uB144(\\d{1,2})\\uC6D4(\\d{1,2})\\uC77C"
+    );
+
+    private static final String[] DATE_LABELS = {
+            "\uCDE8\uB4DD\uC77C",
+            "\uCDE8\uB4DD\uC77C\uC790",
+            "\uD569\uACA9\uC77C",
+            "\uD569\uACA9\uC77C\uC790",
+            "\uD569\uACA9\uC5F0\uC6D4\uC77C",
+            "\uBC1C\uAE09\uC77C",
+            "\uBC1C\uAE09\uC5F0\uC6D4\uC77C",
+            "\uC790\uACA9\uCDE8\uB4DD\uC77C",
+            "\uC790\uACA9\uC99D\uCDE8\uB4DD\uC77C",
+            "\uC790\uACA9\uC744\uCDE8\uB4DD"
+    };
+
+    private static final String[] DATE_CONTEXT_KEYWORDS = {
+            "\uCDE8\uB4DD",
+            "\uD569\uACA9",
+            "\uC790\uACA9\uC744\uCDE8\uB4DD",
+            "\uD569\uACA9\uD558\uC600\uC74C",
+            "\uD655\uC778\uD569\uB2C8\uB2E4"
+    };
+
+    private static final String[] DATE_EXCLUDE_KEYWORDS = {
+            "\uC720\uD6A8\uAE30\uAC04",
+            "\uC0DD\uB144\uC6D4\uC77C",
+            "\uCD9C\uB825\uC77C",
+            "\uBC1C\uAE09\uBC88\uD638"
+    };
+
+    private static final String[] PASS_KEYWORDS = {
+            "\uD569\uACA9",
+            "\uD569\uACA9\uC99D",
+            "\uD569\uACA9\uC778\uC99D\uC11C",
+            "\uCDE8\uB4DD",
+            "\uC778\uC99D",
+            "\uD655\uC778",
+            "\uC790\uACA9\uCDE8\uB4DD"
+    };
+
     private static final String[] INVALID_DOCUMENT_KEYWORDS = {
-            "예시", "샘플", "수험표", "접수확인"
+            "\uC608\uC2DC",
+            "\uC0D8\uD50C",
+            "\uC0D8\uD50C\uBB38\uC11C",
+            "\uC811\uC218\uD655\uC778"
     };
 
     private final CertificateMasterRepository certificateMasterRepository;
+    private final CertificateIssuerAliasRepository certificateIssuerAliasRepository;
 
-    public CertificateVerificationService(CertificateMasterRepository certificateMasterRepository) {
+    public CertificateVerificationService(
+            CertificateMasterRepository certificateMasterRepository,
+            CertificateIssuerAliasRepository certificateIssuerAliasRepository
+    ) {
         this.certificateMasterRepository = certificateMasterRepository;
+        this.certificateIssuerAliasRepository = certificateIssuerAliasRepository;
     }
 
     public CertificateMatchResult verify(Long certificateId, String extractedText, Member member) {
         CertificateMaster certificateMaster = certificateMasterRepository.findByCertificateIdAndIsActiveTrue(certificateId)
-                .orElseThrow(() -> new CertificateVerificationException("Active certificate master not found"));
+                .orElseThrow(() -> new CertificateVerificationException("\uD65C\uC131\uD654\uB41C \uC790\uACA9\uC99D \uAE30\uC900 \uC815\uBCF4\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4."));
 
         if (extractedText == null || extractedText.isBlank()) {
             return new CertificateMatchResult(
@@ -47,9 +101,9 @@ public class CertificateVerificationService {
 
         String normalizedText = normalize(extractedText);
         String detectedName = extractName(extractedText);
-        boolean nameMatched = matchesName(member.getName(), detectedName, normalizedText);
+        boolean nameMatched = matchesName(member.getName(), detectedName, normalizedText, extractedText);
         boolean certificateNameMatched = contains(normalizedText, certificateMaster.getCertificateName());
-        boolean issuerNameMatched = contains(normalizedText, certificateMaster.getIssuerName());
+        boolean issuerNameMatched = matchesIssuer(certificateId, certificateMaster.getIssuerName(), normalizedText);
         boolean passKeywordMatched = containsAny(normalizedText, PASS_KEYWORDS);
         boolean invalidDocumentMatched = containsAny(normalizedText, INVALID_DOCUMENT_KEYWORDS);
 
@@ -61,19 +115,139 @@ public class CertificateVerificationService {
             );
         }
 
-        String failureReason = buildFailureReason(
-                nameMatched,
-                certificateNameMatched,
-                issuerNameMatched,
-                passKeywordMatched,
-                invalidDocumentMatched
-        );
-
         return new CertificateMatchResult(
                 CertificateVerificationStatus.VERIFICATION_FAILED,
                 null,
-                failureReason
+                buildFailureReason(
+                        nameMatched,
+                        certificateNameMatched,
+                        issuerNameMatched,
+                        passKeywordMatched,
+                        invalidDocumentMatched
+                )
         );
+    }
+
+    public LocalDate extractCertificateDate(String extractedText) {
+        if (extractedText == null || extractedText.isBlank()) {
+            return null;
+        }
+
+        String compactText = compactForDateExtraction(extractedText);
+        LocalDate labeledDate = extractDateFromLabeledPattern(compactText);
+        if (labeledDate != null) {
+            return labeledDate;
+        }
+
+        LocalDate dateFromLabeledText = extractDateNearLabels(compactText);
+        if (dateFromLabeledText != null) {
+            return dateFromLabeledText;
+        }
+
+        LocalDate dateFromContext = extractDateNearContext(compactText);
+        if (dateFromContext != null) {
+            return dateFromContext;
+        }
+
+        return extractDateFromText(compactText);
+    }
+
+    private LocalDate extractDateFromLabeledPattern(String compactText) {
+        Matcher matcher = LABELED_DATE_PATTERN.matcher(compactText);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        try {
+            return LocalDate.of(
+                    Integer.parseInt(matcher.group(2)),
+                    Integer.parseInt(matcher.group(3)),
+                    Integer.parseInt(matcher.group(4))
+            );
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private LocalDate extractDateFromText(String text) {
+        for (Pattern pattern : DATE_PATTERNS) {
+            Matcher matcher = pattern.matcher(text);
+            while (matcher.find()) {
+                try {
+                    return LocalDate.of(
+                            Integer.parseInt(matcher.group(1)),
+                            Integer.parseInt(matcher.group(2)),
+                            Integer.parseInt(matcher.group(3))
+                    );
+                } catch (RuntimeException ignored) {
+                    // Continue scanning.
+                }
+            }
+        }
+        return null;
+    }
+
+    private LocalDate extractDateNearLabels(String compactText) {
+        for (String label : DATE_LABELS) {
+            int labelIndex = compactText.indexOf(label);
+            if (labelIndex < 0) {
+                continue;
+            }
+
+            int start = labelIndex + label.length();
+            int end = Math.min(compactText.length(), start + 40);
+            LocalDate extractedDate = extractDateFromText(compactText.substring(start, end));
+            if (extractedDate != null) {
+                return extractedDate;
+            }
+        }
+
+        return null;
+    }
+
+    private LocalDate extractDateNearContext(String compactText) {
+        for (Pattern pattern : DATE_PATTERNS) {
+            Matcher matcher = pattern.matcher(compactText);
+            while (matcher.find()) {
+                int start = Math.max(0, matcher.start() - 30);
+                int end = Math.min(compactText.length(), matcher.end() + 30);
+                String context = compactText.substring(start, end);
+
+                if (containsAnyKeyword(context, DATE_EXCLUDE_KEYWORDS)) {
+                    continue;
+                }
+                if (!containsAnyKeyword(context, DATE_CONTEXT_KEYWORDS)) {
+                    continue;
+                }
+
+                try {
+                    return LocalDate.of(
+                            Integer.parseInt(matcher.group(1)),
+                            Integer.parseInt(matcher.group(2)),
+                            Integer.parseInt(matcher.group(3))
+                    );
+                } catch (RuntimeException ignored) {
+                    // Continue scanning.
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private boolean containsAnyKeyword(String text, String[] keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String compactForDateExtraction(String text) {
+        return text
+                .replaceAll("\\s+", "")
+                .replace("\u3000", "");
     }
 
     private String buildFailureReason(
@@ -104,45 +278,88 @@ public class CertificateVerificationService {
     private String extractName(String extractedText) {
         Matcher matcher = NAME_PATTERN.matcher(extractedText);
         if (!matcher.find()) {
-            return null;
+            String compactText = compactForDateExtraction(extractedText);
+            Matcher compactMatcher = Pattern.compile("(?:\\uC131\\uBA85|\\uC774\\uB984)([\\uAC00-\\uD7A3]{2,10})").matcher(compactText);
+            if (!compactMatcher.find()) {
+                return null;
+            }
+            return compactMatcher.group(1);
         }
-
         return matcher.group(1);
     }
 
-    private boolean matchesName(String memberName, String detectedName, String normalizedText) {
+    private boolean matchesName(String memberName, String detectedName, String normalizedText, String extractedText) {
         if (contains(normalizedText, memberName)) {
             return true;
         }
+
+        String normalizedMemberName = normalize(memberName);
+        if (containsNameWithSingleCharacterMismatch(extractedText, normalizedMemberName)) {
+            return true;
+        }
+
         if (detectedName == null || detectedName.isBlank()) {
             return false;
         }
 
-        String normalizedMemberName = normalize(memberName);
         String normalizedDetectedName = normalize(detectedName);
         if (normalizedMemberName.equals(normalizedDetectedName)) {
             return true;
         }
 
-        return hasSingleCharacterMismatch(normalizedMemberName, normalizedDetectedName);
+        return hasAllowedNameMismatch(normalizedMemberName, normalizedDetectedName);
+    }
+
+    private boolean containsNameWithSingleCharacterMismatch(String extractedText, String normalizedMemberName) {
+        String koreanOnlyText = extractKoreanOnly(extractedText);
+        int targetLength = normalizedMemberName.length();
+        if (targetLength == 0 || koreanOnlyText.length() < targetLength) {
+            return false;
+        }
+
+        for (int index = 0; index <= koreanOnlyText.length() - targetLength; index++) {
+            String candidate = koreanOnlyText.substring(index, index + targetLength);
+            if (normalizedMemberName.equals(candidate) || hasAllowedNameMismatch(normalizedMemberName, candidate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String extractKoreanOnly(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return Normalizer.normalize(value, Normalizer.Form.NFKC)
+                .replaceAll("[^\\uAC00-\\uD7A3]", "");
+    }
+
+    private boolean hasAllowedNameMismatch(String expected, String actual) {
+        int mismatchThreshold = expected.length() <= 3 ? 2 : 1;
+        return hasCharacterMismatchWithinThreshold(expected, actual, mismatchThreshold);
     }
 
     private boolean hasSingleCharacterMismatch(String expected, String actual) {
+        return hasCharacterMismatchWithinThreshold(expected, actual, 1);
+    }
+
+    private boolean hasCharacterMismatchWithinThreshold(String expected, String actual, int threshold) {
         if (expected.length() != actual.length() || expected.isBlank()) {
             return false;
         }
 
         int mismatchCount = 0;
-        for (int i = 0; i < expected.length(); i++) {
-            if (expected.charAt(i) != actual.charAt(i)) {
+        for (int index = 0; index < expected.length(); index++) {
+            if (expected.charAt(index) != actual.charAt(index)) {
                 mismatchCount++;
-                if (mismatchCount > 1) {
+                if (mismatchCount > threshold) {
                     return false;
                 }
             }
         }
 
-        return mismatchCount == 1;
+        return mismatchCount > 0;
     }
 
     private boolean containsAny(String normalizedText, String... values) {
@@ -159,8 +376,69 @@ public class CertificateVerificationService {
         if (normalizedExpectedValue.isBlank()) {
             return false;
         }
-
         return normalizedText.contains(normalizedExpectedValue);
+    }
+
+    private boolean matchesIssuer(Long certificateId, String issuerName, String normalizedText) {
+        if (contains(normalizedText, issuerName)) {
+            return true;
+        }
+
+        String simplifiedIssuerName = simplifyIssuerName(issuerName);
+        if (contains(normalizedText, simplifiedIssuerName)) {
+            return true;
+        }
+        if (containsWithSingleCharacterMismatch(normalizedText, simplifiedIssuerName)) {
+            return true;
+        }
+
+        for (CertificateIssuerAlias alias : certificateIssuerAliasRepository.findAllByCertificateIdAndIsActiveTrue(certificateId)) {
+            if (contains(normalizedText, alias.getIssuerName())) {
+                return true;
+            }
+            if (contains(normalizedText, simplifyIssuerName(alias.getIssuerName()))) {
+                return true;
+            }
+            if (containsWithSingleCharacterMismatch(normalizedText, simplifyIssuerName(alias.getIssuerName()))) {
+                return true;
+            }
+            if (contains(normalizedText, alias.getIssuerNameEn())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean containsWithSingleCharacterMismatch(String normalizedText, String expectedValue) {
+        String normalizedExpectedValue = normalize(expectedValue);
+        int targetLength = normalizedExpectedValue.length();
+        if (normalizedExpectedValue.isBlank() || normalizedText.length() < targetLength) {
+            return false;
+        }
+
+        for (int index = 0; index <= normalizedText.length() - targetLength; index++) {
+            String candidate = normalizedText.substring(index, index + targetLength);
+            if (normalizedExpectedValue.equals(candidate) || hasSingleCharacterMismatch(normalizedExpectedValue, candidate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String simplifyIssuerName(String issuerName) {
+        if (issuerName == null || issuerName.isBlank()) {
+            return "";
+        }
+
+        return issuerName
+                .replace("\uC6D0\uC7A5", "")
+                .replace("\uD68C\uC7A5", "")
+                .replace("\uC774\uC0AC\uC7A5", "")
+                .replace("\uC7A5\uAD00", "")
+                .replace("\uC6D0", "")
+                .trim();
     }
 
     private String normalize(String value) {
@@ -170,7 +448,6 @@ public class CertificateVerificationService {
 
         String normalized = Normalizer.normalize(value, Normalizer.Form.NFKC)
                 .toLowerCase(Locale.ROOT);
-
         return normalized.replaceAll("[^\\p{IsAlphabetic}\\p{IsDigit}]", "");
     }
 }

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -307,7 +307,7 @@ public class CertificateVerificationService {
             return true;
         }
 
-        return hasAllowedNameMismatch(normalizedMemberName, normalizedDetectedName);
+        return hasLabelBasedNameMismatch(normalizedMemberName, normalizedDetectedName);
     }
 
     private boolean containsNameWithSingleCharacterMismatch(String extractedText, String normalizedMemberName) {
@@ -335,7 +335,7 @@ public class CertificateVerificationService {
                 .replaceAll("[^\\uAC00-\\uD7A3]", "");
     }
 
-    private boolean hasAllowedNameMismatch(String expected, String actual) {
+    private boolean hasLabelBasedNameMismatch(String expected, String actual) {
         int mismatchThreshold = expected.length() <= 3 ? 2 : 1;
         return hasCharacterMismatchWithinThreshold(expected, actual, mismatchThreshold);
     }
@@ -437,7 +437,6 @@ public class CertificateVerificationService {
                 .replace("\uD68C\uC7A5", "")
                 .replace("\uC774\uC0AC\uC7A5", "")
                 .replace("\uC7A5\uAD00", "")
-                .replace("\uC6D0", "")
                 .trim();
     }
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #134 

---

### 📝 작업 내용
- 자기계발 대출 OCR 인증에 자격증 취득일/합격일/발급일 추출 및 대출 신청일 비교 검증 추가
- OCR 텍스트의 공백이 많은 날짜 표현(`2025 년 07 월 15 일`, `합 격 일 자`)도 인식할 수 있도록 날짜 파싱 보완
- PNG/PDF OCR 결과에서 이름 매칭이 더 안정적으로 동작하도록 본문 전체 기준 비교와 OCR 오차 허용 범위 보강
- 발급기관 검증에 직함 제거, 부분 매칭, issuer alias, 한 글자 OCR 오차 허용을 반영해 OCR 품질 편차 대응 강화
- 중복 인증 및 예외 메시지를 한글 기준으로 정리

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 증명서 발급일자 검증 기능 추가
  * 발급기관명 및 신청자명 매칭 정확도 개선
  * OCR 텍스트 처리 강화로 증명서 인식 개선

* **버그 수정**
  * 증명서 검증 로직 안정화
  * 검증 상태 비교 방식 개선

* **개선사항**
  * 오류 메시지 한국어 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->