### PR TITLE
Feat: 완납 대출 이력 조회 및 동일 상품 재신청 허용 보완

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -317,9 +317,13 @@ public class CertificateVerificationService {
             return false;
         }
 
+        boolean hasNameLabel = hasNameLabel(extractedText);
+
         for (int index = 0; index <= koreanOnlyText.length() - targetLength; index++) {
             String candidate = koreanOnlyText.substring(index, index + targetLength);
-            if (normalizedMemberName.equals(candidate) || hasSingleCharacterMismatch(normalizedMemberName, candidate)) {
+            if (normalizedMemberName.equals(candidate)
+                || hasSingleCharacterMismatch(normalizedMemberName, candidate)
+                || (hasNameLabel && hasLabelBasedNameMismatch(normalizedMemberName, candidate))) {
                 return true;
             }
         }
@@ -342,6 +346,15 @@ public class CertificateVerificationService {
 
     private boolean hasSingleCharacterMismatch(String expected, String actual) {
         return hasCharacterMismatchWithinThreshold(expected, actual, 1);
+    }
+
+    private boolean hasNameLabel(String extractedText) {
+        if (extractedText == null || extractedText.isBlank()) {
+            return false;
+        }
+
+        String compactText = compactForDateExtraction(extractedText);
+        return compactText.contains("\uC131\uBA85") || compactText.contains("\uC774\uB984");
     }
 
     private boolean hasCharacterMismatchWithinThreshold(String expected, String actual, int threshold) {

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -319,7 +319,7 @@ public class CertificateVerificationService {
 
         for (int index = 0; index <= koreanOnlyText.length() - targetLength; index++) {
             String candidate = koreanOnlyText.substring(index, index + targetLength);
-            if (normalizedMemberName.equals(candidate) || hasAllowedNameMismatch(normalizedMemberName, candidate)) {
+            if (normalizedMemberName.equals(candidate) || hasSingleCharacterMismatch(normalizedMemberName, candidate)) {
                 return true;
             }
         }

--- a/src/main/java/com/nudgebank/bankbackend/loan/controller/MyLoanManagementController.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/controller/MyLoanManagementController.java
@@ -1,6 +1,7 @@
 package com.nudgebank.bankbackend.loan.controller;
 
 import com.nudgebank.bankbackend.auth.security.SecurityUtil;
+import com.nudgebank.bankbackend.loan.dto.CompletedLoanHistoryResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentHistoryResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanRepaymentScheduleResponse;
 import com.nudgebank.bankbackend.loan.dto.MyLoanSummaryResponse;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -62,6 +64,51 @@ public class MyLoanManagementController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
         return myLoanManagementService.getRepaymentHistories(memberId, productKey);
+    }
+
+    @GetMapping("/completed")
+    public List<CompletedLoanHistoryResponse> getCompletedLoans(Authentication authentication) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getCompletedLoans(memberId);
+    }
+
+    @GetMapping("/completed/{loanHistoryId}/summary")
+    public MyLoanSummaryResponse getCompletedLoanSummary(
+        Authentication authentication,
+        @PathVariable Long loanHistoryId
+    ) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getCompletedLoanSummary(memberId, loanHistoryId);
+    }
+
+    @GetMapping("/completed/{loanHistoryId}/repayment-schedules")
+    public List<MyLoanRepaymentScheduleResponse> getCompletedRepaymentSchedules(
+        Authentication authentication,
+        @PathVariable Long loanHistoryId
+    ) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getCompletedRepaymentSchedules(memberId, loanHistoryId);
+    }
+
+    @GetMapping("/completed/{loanHistoryId}/repayment-histories")
+    public List<MyLoanRepaymentHistoryResponse> getCompletedRepaymentHistories(
+        Authentication authentication,
+        @PathVariable Long loanHistoryId
+    ) {
+        Long memberId = SecurityUtil.extractUserId(authentication);
+        if (memberId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return myLoanManagementService.getCompletedRepaymentHistories(memberId, loanHistoryId);
     }
 
     @PostMapping("/repayments")

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/CompletedLoanHistoryResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/CompletedLoanHistoryResponse.java
@@ -1,0 +1,17 @@
+package com.nudgebank.bankbackend.loan.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record CompletedLoanHistoryResponse(
+    Long loanHistoryId,
+    String productKey,
+    String productName,
+    String status,
+    BigDecimal totalPrincipal,
+    BigDecimal interestRate,
+    String repaymentType,
+    LocalDate startDate,
+    LocalDate completedAt
+) {
+}

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
@@ -29,4 +29,11 @@ public interface LoanRepository extends JpaRepository<Loan, Long> {
         java.time.LocalDate endDate
     );
 
+    Optional<Loan> findTopByMember_MemberIdAndLoanApplication_Card_CardIdAndPrincipalAmountAndStartDateOrderByIdDesc(
+        Long memberId,
+        Long cardId,
+        java.math.BigDecimal principalAmount,
+        java.time.LocalDate startDate
+    );
+
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/repository/LoanRepository.java
@@ -21,4 +21,12 @@ public interface LoanRepository extends JpaRepository<Loan, Long> {
         String loanProductType
     );
 
+    Optional<Loan> findTopByMember_MemberIdAndLoanApplication_Card_CardIdAndPrincipalAmountAndStartDateAndEndDateOrderByIdDesc(
+        Long memberId,
+        Long cardId,
+        java.math.BigDecimal principalAmount,
+        java.time.LocalDate startDate,
+        java.time.LocalDate endDate
+    );
+
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -85,11 +85,7 @@ public class LoanApplicationService {
         LoanProduct loanProduct = loanProductRepository.findByLoanProductType(loanProductType)
                 .orElseThrow(() -> new EntityNotFoundException("대출 상품을 찾을 수 없습니다. type=" + loanProductType));
 
-        boolean alreadyApplied = loanApplicationRepository
-                .findAllByMember_MemberIdOrderByAppliedAtDesc(member.getMemberId())
-                .stream()
-                .anyMatch(application -> loanProductType.equals(application.getLoanProduct().getLoanProductType())
-                        && application.getApplicationStatus() != LoanApplicationStatus.REJECTED);
+        boolean alreadyApplied = hasOngoingApplication(member.getMemberId(), loanProductType);
 
         if (alreadyApplied) {
             throw new IllegalArgumentException("이미 진행 중이거나 승인된 동일 상품 신청이 있습니다.");
@@ -202,10 +198,7 @@ public class LoanApplicationService {
         LoanProduct loanProduct = loanProductRepository.findByLoanProductType(loanProductType)
             .orElseThrow(() -> new EntityNotFoundException("대출 상품을 찾을 수 없습니다. type=" + loanProductType));
 
-        boolean alreadyApplied = loanApplicationRepository
-            .findAllByMember_MemberIdOrderByAppliedAtDesc(member.getMemberId())
-            .stream()
-            .anyMatch(application -> loanProductType.equals(application.getLoanProduct().getLoanProductType()));
+        boolean alreadyApplied = hasOngoingApplication(member.getMemberId(), loanProductType);
         if (alreadyApplied) {
             throw new IllegalArgumentException("이미 신청이 완료된 상품입니다. 내 대출 관리에서 진행 상태를 확인해 주세요.");
         }
@@ -267,6 +260,38 @@ public class LoanApplicationService {
     }
 
     // 대출 실행
+    private boolean hasOngoingApplication(Long memberId, String loanProductType) {
+        return loanApplicationRepository.findAllByMember_MemberIdOrderByAppliedAtDesc(memberId).stream()
+            .filter(application -> loanProductType.equals(application.getLoanProduct().getLoanProductType()))
+            .anyMatch(this::isApplicationStillInProgress);
+    }
+
+    private boolean isApplicationStillInProgress(LoanApplication application) {
+        if (application.getApplicationStatus() == LoanApplicationStatus.REJECTED) {
+            return false;
+        }
+        if (application.getApplicationStatus() == LoanApplicationStatus.PENDING) {
+            return true;
+        }
+
+        Loan loan = loanRepository.findTopByLoanApplication_IdOrderByIdDesc(application.getId()).orElse(null);
+        if (loan == null || application.getCard() == null) {
+            return true;
+        }
+
+        LoanHistory loanHistory = loanHistoryRepository
+            .findTopByMember_MemberIdAndCard_CardIdAndTotalPrincipalAndStartDateAndEndDateOrderByCreatedAtDesc(
+                application.getMember().getMemberId(),
+                application.getCard().getCardId(),
+                nullSafe(loan.getPrincipalAmount()),
+                loan.getStartDate(),
+                loan.getEndDate()
+            )
+            .orElse(null);
+
+        return loanHistory == null || !"COMPLETED".equals(loanHistory.getStatus());
+    }
+
     private void createLoanExecution(LoanApplication loanApplication, Account repaymentAccount) {
         Card card = loanApplication.getCard();
 

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -387,11 +387,24 @@ public class MyLoanManagementService {
     }
 
     private java.util.Optional<Loan> resolveLoanForHistory(Long memberId, LoanHistory loanHistory) {
+        BigDecimal normalizedPrincipalAmount = WonAmount.floor(loanHistory.getTotalPrincipal());
+
+        java.util.Optional<Loan> matchedLoan = loanRepository
+            .findTopByMember_MemberIdAndLoanApplication_Card_CardIdAndPrincipalAmountAndStartDateOrderByIdDesc(
+                memberId,
+                loanHistory.getCard().getCardId(),
+                normalizedPrincipalAmount,
+                loanHistory.getStartDate()
+            );
+        if (matchedLoan.isPresent()) {
+            return matchedLoan;
+        }
+
         return loanRepository
             .findTopByMember_MemberIdAndLoanApplication_Card_CardIdAndPrincipalAmountAndStartDateAndEndDateOrderByIdDesc(
                 memberId,
                 loanHistory.getCard().getCardId(),
-                nullSafe(loanHistory.getTotalPrincipal()),
+                normalizedPrincipalAmount,
                 loanHistory.getStartDate(),
                 loanHistory.getEndDate()
             );

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -5,6 +5,7 @@ import com.nudgebank.bankbackend.certificate.domain.CertificateSubmission;
 import com.nudgebank.bankbackend.certificate.repository.CertificateMasterRepository;
 import com.nudgebank.bankbackend.certificate.repository.CertificateSubmissionRepository;
 import com.nudgebank.bankbackend.common.util.WonAmount;
+import com.nudgebank.bankbackend.loan.dto.CompletedLoanHistoryResponse;
 import com.nudgebank.bankbackend.loan.domain.Loan;
 import com.nudgebank.bankbackend.loan.domain.LoanApplication;
 import com.nudgebank.bankbackend.loan.domain.LoanHistory;
@@ -156,6 +157,117 @@ public class MyLoanManagementService {
             .toList();
     }
 
+    public List<CompletedLoanHistoryResponse> getCompletedLoans(Long memberId) {
+        return loanHistoryRepository.findAllByMember_MemberIdOrderByCreatedAtDesc(memberId).stream()
+            .filter(loanHistory -> "COMPLETED".equals(loanHistory.getStatus()))
+            .map(loanHistory -> {
+                Loan loan = resolveLoanForHistory(memberId, loanHistory)
+                    .orElseThrow(() -> new EntityNotFoundException("완납 대출 정보를 찾을 수 없습니다."));
+                LoanApplication application = loan.getLoanApplication();
+                return new CompletedLoanHistoryResponse(
+                    loanHistory.getId(),
+                    toProductKey(application.getLoanProduct().getLoanProductType()),
+                    application.getLoanProduct().getLoanProductName(),
+                    loanHistory.getStatus(),
+                    won(loanHistory.getTotalPrincipal()),
+                    nullSafe(loan.getInterestRate()),
+                    application.getLoanProduct().getRepaymentType(),
+                    loanHistory.getStartDate(),
+                    loanHistory.getEndDate()
+                );
+            })
+            .toList();
+    }
+
+    public MyLoanSummaryResponse getCompletedLoanSummary(Long memberId, Long loanHistoryId) {
+        LoanHistory loanHistory = loanHistoryRepository.findById(loanHistoryId)
+            .filter(history -> history.getMember().getMemberId().equals(memberId))
+            .filter(history -> "COMPLETED".equals(history.getStatus()))
+            .orElseThrow(() -> new EntityNotFoundException("완납 대출 이력을 찾을 수 없습니다."));
+
+        Loan loan = resolveLoanForHistory(memberId, loanHistory)
+            .orElseThrow(() -> new EntityNotFoundException("완납 대출 정보를 찾을 수 없습니다."));
+        LoanApplication application = loan.getLoanApplication();
+        List<RepaymentSchedule> schedules =
+            repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId());
+
+        BigDecimal totalPrincipal = nullSafe(loanHistory.getTotalPrincipal());
+        BigDecimal remainingPrincipal = nullSafe(loanHistory.getRemainingPrincipal());
+        BigDecimal repaidPrincipal = totalPrincipal.subtract(remainingPrincipal);
+        BigDecimal cumulativeInterest = schedules.stream()
+            .map(RepaymentSchedule::getPaidInterest)
+            .map(this::nullSafe)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal baseInterestRate = resolveBaseInterestRate(application);
+        BigDecimal minimumInterestRate = resolveMinimumInterestRate(application);
+        BigDecimal currentInterestRate = nullSafe(loan.getInterestRate());
+        BigDecimal preferentialRateDiscount = resolvePreferentialRateDiscount(
+            application.getId(),
+            baseInterestRate,
+            currentInterestRate
+        );
+
+        return new MyLoanSummaryResponse(
+            loanHistory.getId(),
+            loanHistory.getStatus(),
+            won(totalPrincipal),
+            won(remainingPrincipal),
+            won(repaidPrincipal.max(BigDecimal.ZERO)),
+            baseInterestRate,
+            minimumInterestRate,
+            preferentialRateDiscount,
+            currentInterestRate,
+            application.getLoanProduct().getRepaymentType(),
+            loanHistory.getStartDate(),
+            loanHistory.getEndDate(),
+            null,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            won(cumulativeInterest),
+            BigDecimal.ZERO,
+            loanHistory.getRepaymentAccountNumber()
+        );
+    }
+
+    public List<MyLoanRepaymentScheduleResponse> getCompletedRepaymentSchedules(Long memberId, Long loanHistoryId) {
+        LoanHistory loanHistory = loanHistoryRepository.findById(loanHistoryId)
+            .filter(history -> history.getMember().getMemberId().equals(memberId))
+            .filter(history -> "COMPLETED".equals(history.getStatus()))
+            .orElseThrow(() -> new EntityNotFoundException("완납 대출 이력을 찾을 수 없습니다."));
+
+        return repaymentScheduleRepository.findAllByLoanHistory_IdOrderByDueDateAsc(loanHistory.getId()).stream()
+            .map(schedule -> new MyLoanRepaymentScheduleResponse(
+                schedule.getScheduleId(),
+                schedule.getDueDate(),
+                won(schedule.getPlannedPrincipal()),
+                won(schedule.getPlannedInterest()),
+                won(schedule.getPaidPrincipal()),
+                won(schedule.getPaidInterest()),
+                Boolean.TRUE.equals(schedule.getIsSettled()),
+                resolveOverdueDays(schedule)
+            ))
+            .toList();
+    }
+
+    public List<MyLoanRepaymentHistoryResponse> getCompletedRepaymentHistories(Long memberId, Long loanHistoryId) {
+        LoanHistory loanHistory = loanHistoryRepository.findById(loanHistoryId)
+            .filter(history -> history.getMember().getMemberId().equals(memberId))
+            .filter(history -> "COMPLETED".equals(history.getStatus()))
+            .orElseThrow(() -> new EntityNotFoundException("완납 대출 이력을 찾을 수 없습니다."));
+
+        return loanRepaymentHistoryRepository
+            .findTop10ByLoanHistory_IdOrderByRepaymentDatetimeDesc(loanHistory.getId()).stream()
+            .map(history -> new MyLoanRepaymentHistoryResponse(
+                history.getRepaymentId(),
+                won(history.getRepaymentAmount()),
+                nullSafe(history.getRepaymentRate()),
+                history.getRepaymentDatetime(),
+                won(history.getRemainingBalance())
+            ))
+            .toList();
+    }
+
     private MyLoanSummaryResponse buildPendingLoanSummary(Long memberId, String productKey) {
         LoanApplication application = ensureDisplayableLoanExists(memberId, productKey);
         BigDecimal totalPrincipal = won(application.getLoanAmount());
@@ -272,6 +384,17 @@ public class MyLoanManagementService {
         }
 
         return java.util.Optional.empty();
+    }
+
+    private java.util.Optional<Loan> resolveLoanForHistory(Long memberId, LoanHistory loanHistory) {
+        return loanRepository
+            .findTopByMember_MemberIdAndLoanApplication_Card_CardIdAndPrincipalAmountAndStartDateAndEndDateOrderByIdDesc(
+                memberId,
+                loanHistory.getCard().getCardId(),
+                nullSafe(loanHistory.getTotalPrincipal()),
+                loanHistory.getStartDate(),
+                loanHistory.getEndDate()
+            );
     }
 
     private BigDecimal resolveInitialInterestRate(LoanApplication application) {
@@ -574,6 +697,15 @@ public class MyLoanManagementService {
             case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
             case "situate-loan" -> EMERGENCY_TYPE;
             default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
+        };
+    }
+
+    private String toProductKey(String loanProductType) {
+        return switch (loanProductType) {
+            case SELF_DEVELOPMENT_TYPE -> "youth-loan";
+            case CONSUMPTION_ANALYSIS_TYPE -> "consumption-loan";
+            case EMERGENCY_TYPE -> "situate-loan";
+            default -> loanProductType;
         };
     }
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #140 

---

### 📝 작업 내용
- 완납된 대출 이력을 별도로 조회할 수 있도록 완납 목록/상세 조회 API를 추가했습니다.
- 동일 상품에 대해 진행 중인 대출이 없고 완납 이력만 남은 경우에는 다시 신청 가능하도록 중복 신청 제한 로직을 보완했습니다.
- 완납 상세 페이지에서 사용할 수 있도록 완납 대출의 요약, 상환 일정, 최근 상환 내역 조회 구조를 정리했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* 완료된 대출 목록 조회 기능 추가
* 완료된 대출의 상세 요약 정보 조회 기능 추가
* 완료된 대출의 상환 일정 조회 기능 추가
* 완료된 대출의 상환 이력 조회 기능 추가

**개선 사항**
* 대출 신청 검증 로직 개선으로 더욱 정확한 중복 신청 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->