### PR TITLE
Refactor: 대출 상품 최대 한도 기준 통일

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
@@ -27,7 +27,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                 "자격증 취득과 직무 역량 개발이 필요한 청년 고객",
                 new BigDecimal("3.50"),
                 new BigDecimal("5.50"),
-                3_000_000L,
+                5_000_000L,
                 500_000L,
                 12,
                 "MATURITY_LUMP_SUM"
@@ -39,7 +39,7 @@ public class LoanProductInitializer implements CommandLineRunner {
                 "소비 흐름 관리가 필요한 고객",
                 new BigDecimal("4.00"),
                 new BigDecimal("6.50"),
-                5_000_000L,
+                10_000_000L,
                 500_000L,
                 12,
                 "EQUAL_INSTALLMENT"


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #150 

---

### 📝 작업 내용
- 상품 마스터 시드 기준으로 소비분석 대출 최대 한도를 1,000만원으로 조정했습니다.
- 상품 마스터 시드 기준으로 자기계발 대출 최대 한도를 500만원으로 조정했습니다.
- 프론트에 노출되는 상품 안내 문구와 실제 백엔드 상품 데이터가 같은 한도 기준을 사용할 수 있도록 정리했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
