### PR TITLE
Fix: 대출 상품 페이지 데이터 변경

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/auth/config/AdminMemberInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/auth/config/AdminMemberInitializer.java
@@ -1,0 +1,85 @@
+package com.nudgebank.bankbackend.auth.config;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class AdminMemberInitializer implements CommandLineRunner {
+
+  private static final Long ADMIN_MEMBER_ID = 100L;
+  private static final String ADMIN_LOGIN_ID = "admin";
+  private static final String ADMIN_NAME = "관리자";
+  private static final String ADMIN_PASSWORD = "admin";
+  private static final LocalDate ADMIN_BIRTH = LocalDate.of(1990, 1, 1);
+  private static final String ADMIN_GENDER = "남성";
+  private static final String ADMIN_PHONE_NUMBER = "999-9999-9999";
+
+  private final JdbcTemplate jdbcTemplate;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  @Transactional
+  public void run(String... args) {
+    Integer existingByMemberId = jdbcTemplate.queryForObject(
+        "select count(*) from member where member_id = ?",
+        Integer.class,
+        ADMIN_MEMBER_ID
+    );
+
+    if (existingByMemberId != null && existingByMemberId > 0) {
+      syncMemberSequence();
+      return;
+    }
+
+    Integer existingByLoginId = jdbcTemplate.queryForObject(
+        "select count(*) from member where id = ?",
+        Integer.class,
+        ADMIN_LOGIN_ID
+    );
+
+    if (existingByLoginId != null && existingByLoginId > 0) {
+      return;
+    }
+
+    jdbcTemplate.update(
+        """
+        insert into member (
+          member_id,
+          id,
+          name,
+          password,
+          birth,
+          created_at,
+          gender,
+          phone_number
+        ) values (?, ?, ?, ?, ?, now(), ?, ?)
+        """,
+        ADMIN_MEMBER_ID,
+        ADMIN_LOGIN_ID,
+        ADMIN_NAME,
+        passwordEncoder.encode(ADMIN_PASSWORD),
+        ADMIN_BIRTH,
+        ADMIN_GENDER,
+        ADMIN_PHONE_NUMBER
+    );
+
+    syncMemberSequence();
+  }
+
+  private void syncMemberSequence() {
+    jdbcTemplate.execute(
+        """
+        select setval(
+          pg_get_serial_sequence('member', 'member_id'),
+          (select greatest(coalesce(max(member_id), 1), 100) from member)
+        )
+        """
+    );
+  }
+}

--- a/src/main/java/com/nudgebank/bankbackend/card/repository/CardTransactionRepository.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/repository/CardTransactionRepository.java
@@ -23,6 +23,20 @@ public interface CardTransactionRepository extends JpaRepository<CardTransaction
   );
 
   @Query("""
+    select ct
+    from CardTransaction ct
+    where ct.card.cardId = :cardId
+      and ct.transactionDatetime between :start and :end
+      and (ct.menuName is null or ct.menuName not in :excludedMenuNames)
+    """)
+  List<CardTransaction> findSpendingByCardCardIdAndTransactionDatetimeBetween(
+          @Param("cardId") Long cardId,
+          @Param("start") OffsetDateTime start,
+          @Param("end") OffsetDateTime end,
+          @Param("excludedMenuNames") List<String> excludedMenuNames
+  );
+
+  @Query("""
         select coalesce(sum(ct.amount), 0)
         from CardTransaction ct
         where ct.card.cardId = :cardId

--- a/src/main/java/com/nudgebank/bankbackend/card/service/CardHistoryService.java
+++ b/src/main/java/com/nudgebank/bankbackend/card/service/CardHistoryService.java
@@ -29,6 +29,7 @@ public class CardHistoryService {
   private final CardRepository cardRepository;
   private final CardTransactionRepository cardTransactionRepository;
   private final LoanRepaymentHistoryRepository loanRepaymentHistoryRepository;
+  private static final List<String> NON_SPENDING_MENU_NAMES = List.of("넛지 대출", "자기계발 대출");
 
   public CardHistoryService(
       AccountRepository accountRepository,
@@ -138,8 +139,13 @@ public class CardHistoryService {
     OffsetDateTime start = now.atDay(1).atStartOfDay().atOffset(ZoneOffset.ofHours(9));
     OffsetDateTime end = now.plusMonths(1).atDay(1).atStartOfDay().atOffset(ZoneOffset.ofHours(9)).minusNanos(1);
 
-    return cardTransactionRepository.findByCardCardIdAndTransactionDatetimeBetween(cardId, start, end).stream()
-        .map(CardTransaction::getAmount)
-        .reduce(BigDecimal.ZERO, BigDecimal::add);
+    return cardTransactionRepository.findSpendingByCardCardIdAndTransactionDatetimeBetween(
+                    cardId,
+                    start,
+                    end,
+                    NON_SPENDING_MENU_NAMES
+            ).stream()
+            .map(CardTransaction::getAmount)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
   }
 }

--- a/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
@@ -43,18 +43,6 @@ public class LoanProductInitializer implements CommandLineRunner {
                 500_000L,
                 12,
                 "EQUAL_INSTALLMENT"
-            ),
-            new LoanProductSeed(
-                "EMERGENCY",
-                "긴급 대출",
-                "긴급 생활안정 자금 대출",
-                "단기 긴급 자금이 필요한 고객",
-                new BigDecimal("5.00"),
-                new BigDecimal("8.00"),
-                2_000_000L,
-                300_000L,
-                6,
-                "EQUAL_INSTALLMENT"
             )
         );
 

--- a/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/config/LoanProductInitializer.java
@@ -34,7 +34,7 @@ public class LoanProductInitializer implements CommandLineRunner {
             ),
             new LoanProductSeed(
                 "CONSUMPTION_ANALYSIS",
-                "소비분석 대출",
+                "넛지 대출",
                 "소비패턴 기반 맞춤 대출",
                 "소비 흐름 관리가 필요한 고객",
                 new BigDecimal("5.00"),

--- a/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanEligibilityResponse.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/dto/LoanEligibilityResponse.java
@@ -10,6 +10,6 @@ public record LoanEligibilityResponse(
         boolean eligible,          // 최종 대출 가능 여부: true/false
         String decision,           // 내부 판단 결과: APPROVED / REJECTED
         Integer creditScore,       // 조회 시점의 최신 내부 신용점수
-        String productKey,         // 조회 대상 상품 키: youth-loan, consumption-loan, situate-loan
+        String productKey,         // 조회 대상 상품 키: youth-loan, consumption-loan
         List<String> reasons       // 가능/불가 판단 사유 목록
 ) {}

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanApplicationService.java
@@ -48,7 +48,6 @@ public class LoanApplicationService {
 
     private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
     private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
-    private static final String EMERGENCY_TYPE = "EMERGENCY";
     private static final String ACTIVE_STATUS = "ACTIVE";
 
     private static final String LOAN_CATEGORY_NAME = "대출";
@@ -547,7 +546,6 @@ public class LoanApplicationService {
         return switch (productKey) {
             case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
             case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
-            case "situate-loan" -> EMERGENCY_TYPE;
             default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
         };
     }
@@ -556,7 +554,6 @@ public class LoanApplicationService {
         return switch (loanProductType) {
             case SELF_DEVELOPMENT_TYPE -> "youth-loan";
             case CONSUMPTION_ANALYSIS_TYPE -> "consumption-loan";
-            case EMERGENCY_TYPE -> "situate-loan";
             default -> loanProductType;
         };
     }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanEligibilityService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanEligibilityService.java
@@ -21,7 +21,6 @@ public class LoanEligibilityService {
     private static final int MIN_ELIGIBLE_CREDIT_SCORE = 500;
     private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
     private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
-    private static final String EMERGENCY_TYPE = "EMERGENCY";
 
     private final CreditHistoryRepository creditHistoryRepository;
     private final LoanProductRepository loanProductRepository;
@@ -69,7 +68,6 @@ public class LoanEligibilityService {
         return switch (productKey) {
             case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
             case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
-            case "situate-loan" -> EMERGENCY_TYPE;
             default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
         };
     }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/LoanRepaymentService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/LoanRepaymentService.java
@@ -429,7 +429,7 @@ public class LoanRepaymentService {
             && loan.getLoanApplication() != null
             && loan.getLoanApplication().getLoanProduct() != null
             && CONSUMPTION_ANALYSIS_TYPE.equals(loan.getLoanApplication().getLoanProduct().getLoanProductType())) {
-            return "소비분석 대출 상환";
+            return "넛지 대출 상환";
         }
         return "자기계발 대출 상환";
     }

--- a/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
+++ b/src/main/java/com/nudgebank/bankbackend/loan/service/MyLoanManagementService.java
@@ -34,7 +34,6 @@ public class MyLoanManagementService {
 
     private static final String SELF_DEVELOPMENT_TYPE = "SELF_DEVELOPMENT";
     private static final String CONSUMPTION_ANALYSIS_TYPE = "CONSUMPTION_ANALYSIS";
-    private static final String EMERGENCY_TYPE = "EMERGENCY";
     private static final String MATURITY_LUMP_SUM_TYPE = "MATURITY_LUMP_SUM";
     private static final String EQUAL_INSTALLMENT_TYPE = "EQUAL_INSTALLMENT";
 
@@ -738,7 +737,6 @@ public class MyLoanManagementService {
         return switch (productKey) {
             case "youth-loan" -> SELF_DEVELOPMENT_TYPE;
             case "consumption-loan" -> CONSUMPTION_ANALYSIS_TYPE;
-            case "situate-loan" -> EMERGENCY_TYPE;
             default -> throw new IllegalArgumentException("지원하지 않는 상품입니다. productKey=" + productKey);
         };
     }
@@ -747,7 +745,6 @@ public class MyLoanManagementService {
         return switch (loanProductType) {
             case SELF_DEVELOPMENT_TYPE -> "youth-loan";
             case CONSUMPTION_ANALYSIS_TYPE -> "consumption-loan";
-            case EMERGENCY_TYPE -> "situate-loan";
             default -> loanProductType;
         };
     }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #158 

---

### 📝 작업 내용
- 비상금 대출 제거
- 대출 상품명 변경(소비분석 대출 -> 넛지 대출)
- 관리자 Initializer 구현
- 총 지출 계산에서 대출 금액 제거

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
