### PR TITLE
Fix: OCR 합격일자 추출 시 생년월일 오인 방지

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -11,6 +11,9 @@ import com.nudgebank.bankbackend.certificate.repository.CertificateMasterReposit
 import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -149,7 +152,7 @@ public class CertificateVerificationService {
             return dateFromContext;
         }
 
-        return extractDateFromText(compactText);
+        return extractFallbackCertificateDate(compactText);
     }
 
     private LocalDate extractDateFromLabeledPattern(String compactText) {
@@ -185,6 +188,45 @@ public class CertificateVerificationService {
             }
         }
         return null;
+    }
+
+    private LocalDate extractFallbackCertificateDate(String compactText) {
+        List<LocalDate> candidates = new ArrayList<>();
+
+        for (Pattern pattern : DATE_PATTERNS) {
+            Matcher matcher = pattern.matcher(compactText);
+            while (matcher.find()) {
+                int start = Math.max(0, matcher.start() - 20);
+                int end = Math.min(compactText.length(), matcher.end() + 20);
+                String context = compactText.substring(start, end);
+
+                if (containsAnyKeyword(context, DATE_EXCLUDE_KEYWORDS)) {
+                    continue;
+                }
+
+                try {
+                    candidates.add(LocalDate.of(
+                            Integer.parseInt(matcher.group(1)),
+                            Integer.parseInt(matcher.group(2)),
+                            Integer.parseInt(matcher.group(3))
+                    ));
+                } catch (RuntimeException ignored) {
+                    // Continue scanning.
+                }
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+
+        return candidates.stream()
+                .max(Comparator.naturalOrder())
+                .orElse(null);
     }
 
     private LocalDate extractDateNearLabels(String compactText) {

--- a/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
+++ b/src/main/java/com/nudgebank/bankbackend/certificate/service/CertificateVerificationService.java
@@ -12,7 +12,6 @@ import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -31,7 +30,7 @@ public class CertificateVerificationService {
     };
 
     private static final Pattern LABELED_DATE_PATTERN = Pattern.compile(
-            "(\\uCDE8\\uB4DD\\uC77C|\\uCDE8\\uB4DD\\uC77C\\uC790|\\uD569\\uACA9\\uC77C|\\uD569\\uACA9\\uC77C\\uC790|\\uD569\\uACA9\\uC5F0\\uC6D4\\uC77C|\\uBC1C\\uAE09\\uC77C|\\uBC1C\\uAE09\\uC5F0\\uC6D4\\uC77C|\\uC790\\uACA9\\uCDE8\\uB4DD\\uC77C|\\uC790\\uACA9\\uC99D\\uCDE8\\uB4DD\\uC77C|\\uC790\\uACA9\\uC744\\uCDE8\\uB4DD).{0,30}?(20\\d{2})\\uB144(\\d{1,2})\\uC6D4(\\d{1,2})\\uC77C"
+            "(\\uCDE8\\uB4DD\\uC77C|\\uCDE8\\uB4DD\\uC77C\\uC790|\\uD569\\uACA9\\uC77C|\\uD569\\uACA9\\uC77C\\uC790|\\uD569\\uACA9\\uC5F0\\uC6D4\\uC77C|\\uD569\\uACA9\\uB144\\uC6D4\\uC77C|\\uBC1C\\uAE09\\uC77C|\\uBC1C\\uAE09\\uC5F0\\uC6D4\\uC77C|\\uC790\\uACA9\\uCDE8\\uB4DD\\uC77C|\\uC790\\uACA9\\uC99D\\uCDE8\\uB4DD\\uC77C|\\uC790\\uACA9\\uC744\\uCDE8\\uB4DD).{0,40}?(20\\d{2})\\uB144(\\d{1,2})\\uC6D4(\\d{1,2})\\uC77C"
     );
 
     private static final String[] DATE_LABELS = {
@@ -40,6 +39,7 @@ public class CertificateVerificationService {
             "\uD569\uACA9\uC77C",
             "\uD569\uACA9\uC77C\uC790",
             "\uD569\uACA9\uC5F0\uC6D4\uC77C",
+            "\uD569\uACA9\uB144\uC6D4\uC77C",
             "\uBC1C\uAE09\uC77C",
             "\uBC1C\uAE09\uC5F0\uC6D4\uC77C",
             "\uC790\uACA9\uCDE8\uB4DD\uC77C",
@@ -52,14 +52,28 @@ public class CertificateVerificationService {
             "\uD569\uACA9",
             "\uC790\uACA9\uC744\uCDE8\uB4DD",
             "\uD569\uACA9\uD558\uC600\uC74C",
-            "\uD655\uC778\uD569\uB2C8\uB2E4"
+            "\uD655\uC778\uD569\uB2C8\uB2E4",
+            "\uD569\uACA9\uD655\uC778",
+            "\uD569\uACA9\uC99D",
+            "\uD569\uACA9\uC778\uC99D\uC11C",
+            "\uCDE8\uB4DD\uD558\uC600",
+            "\uCDE8\uB4DD\uD558\uC600\uC74C",
+            "\uCDE8\uB4DD\uD569\uB2C8\uB2E4",
+            "\uC790\uACA9\uC744\uCDE8\uB4DD\uD558\uC600",
+            "\uC790\uACA9\uC744\uCDE8\uB4DD\uD558\uC600\uC74C"
     };
 
     private static final String[] DATE_EXCLUDE_KEYWORDS = {
             "\uC720\uD6A8\uAE30\uAC04",
             "\uC0DD\uB144\uC6D4\uC77C",
             "\uCD9C\uB825\uC77C",
-            "\uBC1C\uAE09\uBC88\uD638"
+            "\uBC1C\uAE09\uBC88\uD638",
+            "\uB9CC\uB8CC\uC77C",
+            "\uB9CC\uB8CC\uC5F0\uC6D4\uC77C",
+            "\uC7AC\uBC1C\uAE09",
+            "\uAC31\uC2E0",
+            "\uBCF4\uACE0\uC11C\uC0DD\uC131\uC77C",
+            "\uBC1C\uAE09\uC77C\uC2DC"
     };
 
     private static final String[] PASS_KEYWORDS = {
@@ -224,9 +238,7 @@ public class CertificateVerificationService {
             return candidates.get(0);
         }
 
-        return candidates.stream()
-                .max(Comparator.naturalOrder())
-                .orElse(null);
+        return null;
     }
 
     private LocalDate extractDateNearLabels(String compactText) {
@@ -237,7 +249,7 @@ public class CertificateVerificationService {
             }
 
             int start = labelIndex + label.length();
-            int end = Math.min(compactText.length(), start + 40);
+            int end = Math.min(compactText.length(), start + 60);
             LocalDate extractedDate = extractDateFromText(compactText.substring(start, end));
             if (extractedDate != null) {
                 return extractedDate;
@@ -251,8 +263,8 @@ public class CertificateVerificationService {
         for (Pattern pattern : DATE_PATTERNS) {
             Matcher matcher = pattern.matcher(compactText);
             while (matcher.find()) {
-                int start = Math.max(0, matcher.start() - 30);
-                int end = Math.min(compactText.length(), matcher.end() + 30);
+                int start = Math.max(0, matcher.start() - 45);
+                int end = Math.min(compactText.length(), matcher.end() + 45);
                 String context = compactText.substring(start, end);
 
                 if (containsAnyKeyword(context, DATE_EXCLUDE_KEYWORDS)) {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #167

---

### 📝 작업 내용
- OCR 합격일자 추출 시 생년월일 오인 방지

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증서 검증 개선: 다양한 형식의 인증서에서 발급 날짜를 더 정확하게 인식합니다. 여러 날짜 후보가 감지될 경우 최신 날짜를 우선적으로 선택하여 검증 정확도를 향상시킵니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->