### PR TITLE
Fix: 위험소비 비율 20% 이상 시 자동상환 비율 2%p 상향

### DIFF
--- a/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentPolicyService.java
+++ b/src/main/java/com/nudgebank/bankbackend/finance/service/AutoRepaymentPolicyService.java
@@ -133,8 +133,8 @@ public class AutoRepaymentPolicyService {
         }
 
         if (nullSafe(finalBaseline.getRiskRatio()).compareTo(new BigDecimal("0.20")) >= 0) {
-            ratio = ratio.subtract(new BigDecimal("0.01"));
-            reasons.add("위험 소비 비율이 높아 1% 하향 조정합니다.");
+            ratio = ratio.add(new BigDecimal("0.02"));
+            reasons.add("위험 소비 비율이 높아 2% 상향 조정합니다.");
         }
 
         BigDecimal avgSpending = resolvePolicyAvgSpending(finalBaseline);


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #175 

---

### 📝 작업 내용
- 무엇을 / 왜 / 어떻게 수정했는지 간단히 작성

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **기능 개선**
  * 자동 상환 정책의 위험도 평가 및 상환 비율 산정 기준이 개선되었습니다. 금융 위험도가 높은 고객 계정에 대해 더욱 정교한 상환 비율 조정이 적용되어 더욱 정밀한 신용 평가와 맞춤형 상환 정책 제공이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->